### PR TITLE
scorer: Anthropic Bearer fallback when x-api-key returns 401/403

### DIFF
--- a/docs/glossary/PLUGGABILITY.md
+++ b/docs/glossary/PLUGGABILITY.md
@@ -377,7 +377,68 @@ The 5 contract rules every payload must follow:
 5. Unregistered `schema_version` raises `ValueError` at parse and
    iteration time - the framework refuses to guess at unknown shapes.
 
-## 8. Authoring an exporter
+## 8. Authoring a custom LLM judge backend
+
+`BaseJudgeBackend` is in `belt._public_api.PUBLIC_API` and therefore a stable
+public extension point. Subclass it when you need a provider that the built-in
+backends (`OpenAIBackend`, `AzureBackend`, `AnthropicBackend`, `OllamaBackend`)
+do not support, or when a gateway in front of an existing provider requires
+non-standard auth.
+
+The full abstract interface is documented in the class docstring in
+`belt.scorer.llm.backend`. Two hooks are worth calling out here because they
+interact with the dispatcher and are the most common customisation points:
+
+### 8.1. `auth_retry_headers(original_headers) → dict | None`
+
+Called by `LLMScorer._call_api` (and the preflight helper) when the first
+request returns 401 or 403. Return a replacement header dict to retry once with
+that dict instead. Return `None` (the default) to propagate the error
+immediately without retrying.
+
+Typical use: a corporate WAF that rejects one of two interchangeable auth
+header styles from certain egress IPs (e.g. rejecting `x-api-key` but
+accepting `Authorization: Bearer`).
+
+### 8.2. `record_auth_retry_success() → None`
+
+Called by the dispatcher immediately after an `auth_retry_headers` retry
+succeeds. The default no-op is sufficient for one-shot retries. Override when
+the backend caches the working auth style so subsequent requests emit it
+directly, avoiding a 401/403 round-trip on every call in a multi-trial run.
+
+```python
+from belt import BaseJudgeBackend
+
+class MyGatewayBackend(BaseJudgeBackend):
+    def __init__(self):
+        self._use_bearer = False
+
+    def auth_retry_headers(self, original_headers):
+        if "x-api-key" not in original_headers:
+            return None
+        retry = {k: v for k, v in original_headers.items() if k != "x-api-key"}
+        retry["Authorization"] = f"Bearer {original_headers['x-api-key']}"
+        return retry
+
+    def record_auth_retry_success(self):
+        self._use_bearer = True
+
+    def build_request(self, config, messages, schema):
+        headers = {...}
+        if self._use_bearer:
+            headers["Authorization"] = f"Bearer {api_key}"
+        else:
+            headers["x-api-key"] = api_key
+        return url, headers, body
+```
+
+Both methods are called unconditionally on every `BaseJudgeBackend` instance —
+no `isinstance` or `hasattr` guard is needed. The dispatcher calls
+`auth_retry_headers` only on 401/403 and `record_auth_retry_success` only when
+the retry actually succeeded.
+
+## 9. Authoring an exporter
 
 Reach for an exporter to land a **completed run** somewhere belt
 doesn't write today (CSV, JUnit XML, vendor SaaS, Slack-friendly
@@ -392,14 +453,14 @@ the typed inputs (`results`, trial-expanded `scores`, `run_dir`,
 parsed `benchmark_card`). Signature is closed to modification
 ([principle 3](ARCHITECTURE.md#principle-3-extend-via-abstractions-never-modify-the-framework-core)).
 
-### 8.1. Register it
+### 9.1. Register it
 
 Built-in: register in `exporter/registry.py` AND declare an
 `belt.exporters` entry point in core's `pyproject.toml`. Plugin:
 entry point only. List is `belt doctor` under Exporters - this
 guide deliberately doesn't enumerate.
 
-### 8.2. Non-obvious contracts
+### 9.2. Non-obvious contracts
 
 - **Failure isolation.** `export()` raising surfaces as a one-line
   typed error and the next exporter still runs. Exit code is non-zero
@@ -419,7 +480,7 @@ guide deliberately doesn't enumerate.
   scrubs core provenance but does not inspect plugin output, so don't
   log credentials yourself.
 
-## 9. Authoring a sandbox provider
+## 10. Authoring a sandbox provider
 
 Reach for a sandbox provider when neither built-in (`host`,
 `docker`) can express the isolation model you need - Firecracker
@@ -436,7 +497,7 @@ the `belt.sandbox_providers` entry-point group; selection is via
 [CONFIGURATION.md → `SandboxProfile`](CONFIGURATION.md#3-environment-variables)
 for the per-group schema your provider receives.
 
-### 9.1. Register it
+### 10.1. Register it
 
 Built-in: register in `src/belt/runner/sandbox/registry.py`. Plugin:
 declare a `belt.sandbox_providers` entry point in `pyproject.toml`:
@@ -449,7 +510,7 @@ firecracker = "my_plugin:FirecrackerSandboxProvider"
 `belt doctor` then enumerates the provider under "Sandbox" alongside
 `host` and `docker`.
 
-### 9.2. The four method contracts
+### 10.2. The four method contracts
 
 ```python
 from belt import BaseSandboxProvider, SandboxContext, SandboxHandle
@@ -481,7 +542,7 @@ class FirecrackerSandboxProvider(BaseSandboxProvider):
         ...
 ```
 
-### 9.3. Hard contracts
+### 10.3. Hard contracts
 
 | Invariant | Why |
 |---|---|
@@ -492,7 +553,7 @@ class FirecrackerSandboxProvider(BaseSandboxProvider):
 | `wrap()` filters `env` to `ctx.agent_required_env ∪ profile.env_passthrough` | Anything else leaks secrets the scenario did not opt into into the sandbox |
 | `wrap()` returns a triple - never mutates the inputs | The spawner forwards it verbatim to `Popen`; mutating the inputs causes subtle cross-scenario state bleed |
 
-### 9.4. Test gates
+### 10.4. Test gates
 
 Two checks the framework enforces uniformly for every registered
 provider:

--- a/src/belt/scorer/llm/backend.py
+++ b/src/belt/scorer/llm/backend.py
@@ -191,6 +191,61 @@ def _do_get_preflight(
             body,
         )
         return
+    # Auth failed. A genuine auth rejection (401/403) is worth retrying with
+    # the backend's fallback auth style; a 404 means the model name is wrong,
+    # so skip the retry and fall through to the clean single-body abort below.
+    retry_headers = backend.auth_retry_headers(headers) if code in (401, 403) else None
+    if retry_headers is not None:
+        logger.warning(
+            "{} preflight HTTP {} with primary auth header; retrying once " "with backend-supplied fallback headers.",
+            provider,
+            code,
+        )
+        try:
+            resp2 = httpx.get(url, headers=retry_headers, timeout=effective_timeout)
+        except (httpx.TimeoutException, httpx.HTTPError) as exc:
+            logger.warning(
+                "{} preflight retry transient failure for model {!r}: {}; "
+                "proceeding (runtime judge-infra path will handle real failures).",
+                provider,
+                model,
+                exc,
+            )
+            return
+        if resp2.status_code < 400:
+            backend.record_auth_retry_success()
+            return
+        retry_code = resp2.status_code
+        retry_body = resp2.text[:600]
+        # Classify the retry the same way as the primary attempt so transient
+        # hiccups (5xx, 429, network) proceed and only a real auth/config
+        # failure aborts — both attempts share one policy.
+        try:
+            resp2.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            retry_token = backend.classify_error(exc) or "other"
+        else:  # pragma: no cover - resp.raise_for_status always raises here
+            retry_token = "other"
+        if retry_token != "auth_failed":
+            logger.warning(
+                "{} preflight retry transient HTTP {} for model {!r}: {}; "
+                "proceeding (runtime judge-infra path will handle real failures).",
+                provider,
+                retry_code,
+                model,
+                retry_body,
+            )
+            return
+        # Auth retry also rejected — config bug; report both attempts.
+        primary_body = body
+        hint = format_judge_error_hint(retry_code, retry_body)
+        raise ScorerError(
+            f"{provider} judge preflight failed for model {model!r}: "
+            f"HTTP {code}+{retry_code} (auth retry didn't help)\n"
+            f"  Primary: {primary_body[:300]}\n"
+            f"  Retry:   {retry_body[:300]}\n"
+            f"  {hint}"
+        )
     hint = format_judge_error_hint(code, body)
     raise ScorerError(
         f"{provider} judge preflight failed for model {model!r}: HTTP {code}\n" f"  Upstream body: {body}\n" f"  {hint}"
@@ -283,6 +338,39 @@ class BaseJudgeBackend(ABC):
             return "timeout"
         if isinstance(exc, httpx.HTTPError):
             return "other"
+        return None
+
+    # Design note: auth fallback is exposed as an optional method with a safe
+    # default (return None) instead of letting the dispatcher sniff capabilities
+    # via isinstance/hasattr. Capability branching in the framework core is what
+    # Principle 5 (graceful degradation via optional defaults, not branching)
+    # forbids — so backends opt in by overriding, and LLMScorer stays
+    # unconditional. record_auth_retry_success() follows the same rationale.
+    def auth_retry_headers(self, original_headers: dict[str, str]) -> dict[str, str] | None:
+        """Return alternate auth headers to retry once with after a 401/403.
+
+        Called by the judge dispatcher (and the preflight helper) when the
+        provider returns 401/403 on the first attempt. A backend that knows
+        the gateway in front of it accepts more than one auth header style
+        (e.g. JFrog's gateway: WAF allows ``Authorization: Bearer <jwt>``
+        but rejects ``x-api-key: <jwt>`` from some egress IPs) returns the
+        replacement header dict here. The dispatcher reissues the POST
+        once with those headers and, on success, the backend should cache
+        which style worked so subsequent requests skip the failed style.
+
+        Returns ``None`` (the default) when no fallback is meaningful — the
+        caller propagates the 401/403 as it would today.
+        """
+        return None
+
+    def record_auth_retry_success(self) -> None:
+        """Called by the dispatcher after the auth-retry attempt succeeds.
+
+        Backends that cache the working auth style (to avoid re-paying the
+        failed-style round-trip on every subsequent request) override this to
+        record the success. The default no-op keeps callers unconditional —
+        no ``hasattr`` guard needed.
+        """
         return None
 
 
@@ -631,8 +719,34 @@ class AnthropicBackend(BaseJudgeBackend):
         BELT_ANTHROPIC_BASE_URL - optional, defaults to https://api.anthropic.com
     """
 
+    def __init__(self) -> None:
+        # Per-process cache: once we've seen Bearer succeed (typically
+        # because a WAF in front of the gateway rejected x-api-key), every
+        # subsequent build_request emits Bearer directly. Avoids paying a
+        # 401/403 round-trip on every single judge call in a CI run.
+        # Single-boolean assignment is atomic under the GIL, so no lock
+        # is needed when --workers N > 1; worst case: two threads both see
+        # False and each do one extra retry before converging on True.
+        self._use_bearer = False
+
+    def record_auth_retry_success(self) -> None:
+        """Record that the alternate auth style succeeded — emit it on subsequent calls."""
+        self._use_bearer = True
+
     def provider_name(self) -> str:
         return "Anthropic"
+
+    def auth_retry_headers(self, original_headers: dict[str, str]) -> dict[str, str] | None:
+        # Swap x-api-key → Authorization: Bearer. The JFrog gateway's WAF
+        # rejects x-api-key from runner-pool egress with a CloudFront 403
+        # but accepts Bearer; outside that environment Anthropic's own API
+        # also accepts Bearer (undocumented but stable since v1).
+        api_key = original_headers.get("x-api-key")
+        if not api_key:
+            return None
+        retry = {k: v for k, v in original_headers.items() if k != "x-api-key"}
+        retry["Authorization"] = f"Bearer {api_key}"
+        return retry
 
     def is_available(self) -> bool:
         return bool(os.environ.get(envvars.ANTHROPIC_API_KEY))
@@ -669,11 +783,14 @@ class AnthropicBackend(BaseJudgeBackend):
         api_key = os.environ[envvars.ANTHROPIC_API_KEY]
         base = self._resolve_base_url()
         url = f"{base}/v1/messages"
-        headers = {
-            "x-api-key": api_key,
+        headers: dict[str, str] = {
             "Content-Type": "application/json",
             "anthropic-version": "2023-06-01",
         }
+        if self._use_bearer:
+            headers["Authorization"] = f"Bearer {api_key}"
+        else:
+            headers["x-api-key"] = api_key
 
         system_parts = [m["content"] for m in messages if m["role"] == "system"]
         system_text = "\n\n".join(system_parts)

--- a/src/belt/scorer/llm/scorer.py
+++ b/src/belt/scorer/llm/scorer.py
@@ -613,6 +613,12 @@ class LLMScorer(BaseScorer):
             logger.error("Backend auth failed: {}", e)
             raise JudgeInfraError("auth_failed", f"Backend auth failed: {e}") from e
 
+        # Mutable list wrapping headers so the auth-retry path can swap in
+        # fallback headers without redefining _post — the backoff decorator
+        # captures _post at decoration time, so nonlocal reassignment would not
+        # affect the closure. Single-element list is the canonical Python idiom.
+        _headers_ref: list[dict[str, str]] = [headers]
+
         @backoff.on_exception(
             backoff.expo,
             httpx.HTTPStatusError,
@@ -623,7 +629,7 @@ class LLMScorer(BaseScorer):
             ),
         )
         def _post() -> httpx.Response:
-            resp = httpx.post(url, json=body, headers=headers, timeout=120)
+            resp = httpx.post(url, json=body, headers=_headers_ref[0], timeout=120)
             resp.raise_for_status()
             return resp
 
@@ -631,7 +637,50 @@ class LLMScorer(BaseScorer):
             resp = _post()
         except httpx.HTTPStatusError as e:
             code = e.response.status_code
-            error_body = e.response.text[:300]
+            primary_body = e.response.text[:300]
+            # 401/403: ask the backend whether an alternate auth header is
+            # worth retrying once. This covers gateways whose WAF rejects
+            # one of two interchangeable auth styles (notably JFrog's
+            # gateway accepting Bearer but not x-api-key from CI runners).
+            # The hook returns None for backends with no fallback.
+            if code in (401, 403):
+                retry_headers = backend.auth_retry_headers(_headers_ref[0])
+                if retry_headers is not None:
+                    logger.warning(
+                        "LLM judge HTTP {} with primary auth header; "
+                        "retrying once with backend-supplied fallback headers.",
+                        code,
+                    )
+                    _headers_ref[0] = retry_headers
+                    try:
+                        resp = _post()
+                    except httpx.HTTPStatusError as e2:
+                        retry_code = e2.response.status_code
+                        retry_body = e2.response.text[:300]
+                        if retry_code in (401, 403, 404):
+                            from belt.scorer.llm.judge_hints import format_judge_error_hint
+
+                            hint = format_judge_error_hint(retry_code, retry_body)
+                            raise ScorerError(
+                                f"LLM judge fatal HTTP {code}+{retry_code} (auth retry didn't help):\n"
+                                f"  Primary: {primary_body[:300]}\n"
+                                f"  Retry:   {retry_body[:300]}\n"
+                                f"  {hint}"
+                            ) from e2
+                        logger.error("LLM judge HTTP {}: {}", retry_code, retry_body)
+                        etype = backend.classify_error(e2) or "other"
+                        raise JudgeInfraError(etype, f"LLM judge HTTP {retry_code}: {retry_body}") from e2
+                    except httpx.TimeoutException as e2:
+                        logger.error("LLM judge auth-retry request timed out (120s)")
+                        etype = backend.classify_error(e2) or "timeout"
+                        raise JudgeInfraError(etype, "LLM judge auth-retry request timed out (120s)") from e2
+                    except httpx.HTTPError as e2:
+                        logger.error("LLM judge auth-retry request failed: {}", e2)
+                        etype = backend.classify_error(e2) or "other"
+                        raise JudgeInfraError(etype, f"LLM judge auth-retry request failed: {e2}") from e2
+                    else:
+                        backend.record_auth_retry_success()
+                        return self._finalize(resp, cache_key, backend)
             # 401/403/404 are config bugs the user must fix before any more
             # scoring can succeed; aborting the run is faster feedback than
             # producing N silent "judge errored" verdicts in a row. The
@@ -642,14 +691,14 @@ class LLMScorer(BaseScorer):
                 from belt.scorer.llm.judge_hints import format_judge_error_hint
 
                 raise ScorerError(
-                    f"LLM judge fatal HTTP {code}: {error_body}\n" f"{format_judge_error_hint(code, error_body)}"
+                    f"LLM judge fatal HTTP {code}: {primary_body}\n" f"{format_judge_error_hint(code, primary_body)}"
                 ) from e
             # Transient: classify via the backend so provider-specific shapes
             # (Ollama, custom OpenAI-compatible servers) map onto the same
             # JUDGE_ERROR_TYPES tokens through one extension point.
-            logger.error("LLM judge HTTP {}: {}", code, error_body)
+            logger.error("LLM judge HTTP {}: {}", code, primary_body)
             etype = backend.classify_error(e) or "other"
-            raise JudgeInfraError(etype, f"LLM judge HTTP {code}: {error_body}") from e
+            raise JudgeInfraError(etype, f"LLM judge HTTP {code}: {primary_body}") from e
         except httpx.TimeoutException as e:
             logger.error("LLM judge request timed out (120s)")
             etype = backend.classify_error(e) or "timeout"
@@ -669,13 +718,26 @@ class LLMScorer(BaseScorer):
             etype = backend.classify_error(e) or "other"
             raise JudgeInfraError(etype, f"LLM judge unexpected error: {e}") from e
 
+        return self._finalize(resp, cache_key, backend)
+
+    def _finalize(
+        self,
+        resp: httpx.Response,
+        cache_key: "str | None",
+        backend: BaseJudgeBackend,
+    ) -> "tuple[JudgeVerdict | None, dict[str, Any] | None]":
         verdict, usage = self._parse_response(resp, backend)
-
-        # Store in cache
-        if verdict is not None and self.cache is not None:
-            self.cache.put(cache_key, {"verdict": verdict.model_dump(mode="json"), "usage": usage or {}})
-
+        self._cache_put(cache_key, verdict, usage)
         return verdict, usage
+
+    def _cache_put(
+        self,
+        cache_key: str | None,
+        verdict: "JudgeVerdict | None",
+        usage: "dict[str, Any] | None",
+    ) -> None:
+        if verdict is not None and self.cache is not None and cache_key is not None:
+            self.cache.put(cache_key, {"verdict": verdict.model_dump(mode="json"), "usage": usage or {}})
 
     def _parse_response(
         self, resp: httpx.Response, backend: BaseJudgeBackend

--- a/tests/scorer/llm/test_backend.py
+++ b/tests/scorer/llm/test_backend.py
@@ -453,3 +453,310 @@ class TestOllamaBackend:
 
         with patch("httpx.get", side_effect=_httpx.TimeoutException("timeout")):
             assert OllamaBackend().is_available() is False
+
+
+class TestAnthropicAuthRetryHeaders:
+    """Anthropic backend offers Authorization: Bearer as a fallback for x-api-key."""
+
+    def test_returns_bearer_when_original_used_x_api_key(self):
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        backend = AnthropicBackend()
+        original = {
+            "x-api-key": "jwt-token-value",
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        }
+        retry = backend.auth_retry_headers(original)
+        assert retry is not None
+        assert retry["Authorization"] == "Bearer jwt-token-value"
+        assert "x-api-key" not in retry
+        # Other headers are preserved verbatim.
+        assert retry["Content-Type"] == "application/json"
+        assert retry["anthropic-version"] == "2023-06-01"
+
+    def test_returns_none_when_already_bearer(self):
+        """Once we've switched to Bearer (cached), don't loop back to x-api-key."""
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        backend = AnthropicBackend()
+        original = {
+            "Authorization": "Bearer jwt-token-value",
+            "Content-Type": "application/json",
+        }
+        assert backend.auth_retry_headers(original) is None
+
+    def test_returns_none_when_no_auth_header(self):
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        backend = AnthropicBackend()
+        assert backend.auth_retry_headers({"Content-Type": "application/json"}) is None
+
+
+class TestAnthropicHeaderCache:
+    """Once Bearer succeeded, build_request emits Bearer directly on next call."""
+
+    def test_build_request_uses_bearer_after_record_auth_retry_success(self):
+        import os
+        from unittest.mock import patch
+
+        from belt.scorer.entities import JudgeConfig
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        backend = AnthropicBackend()
+        config = JudgeConfig(
+            model="anthropic/claude-sonnet-4-5",
+            temperature=0.0,
+            seed=2008,
+            max_tokens=4096,
+        )
+        # Default: x-api-key.
+        with patch.dict(os.environ, {"BELT_ANTHROPIC_API_KEY": "jwt-tok"}, clear=False):
+            _, headers, _ = backend.build_request(config, [{"role": "user", "content": "hi"}], {"type": "object"})
+            assert headers.get("x-api-key") == "jwt-tok"
+            assert "Authorization" not in headers
+
+            # Caller marks Bearer as the working style after a successful retry.
+            backend.record_auth_retry_success()
+
+            _, headers2, _ = backend.build_request(config, [{"role": "user", "content": "hi"}], {"type": "object"})
+            assert headers2.get("Authorization") == "Bearer jwt-tok"
+            assert "x-api-key" not in headers2
+
+
+class TestPreflightAuthRetry:
+    """Preflight 401/403 also retries with backend-supplied fallback headers."""
+
+    def test_preflight_403_retries_with_bearer(self):
+        import os
+        from unittest.mock import patch
+
+        import httpx
+
+        from belt.scorer.entities import JudgeConfig
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        captured_headers: list[dict[str, str]] = []
+
+        request = httpx.Request("GET", "https://gw.example/anthropic/v1/models/claude-sonnet-4-5")
+        resp_403 = httpx.Response(403, request=request, text="<H1>403</H1>")
+        resp_200 = httpx.Response(
+            200,
+            request=request,
+            json={"id": "claude-sonnet-4-5", "type": "model"},
+        )
+
+        def fake_get(url, headers, timeout):
+            captured_headers.append(dict(headers))
+            return resp_200 if len(captured_headers) >= 2 else resp_403
+
+        backend = AnthropicBackend()
+        env = {"BELT_ANTHROPIC_API_KEY": "jwt-token", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        with patch.dict(os.environ, env, clear=False), patch("belt.scorer.llm.backend.httpx.get", side_effect=fake_get):
+            config = JudgeConfig(
+                model="anthropic/claude-sonnet-4-5",
+                temperature=0.0,
+                seed=2008,
+                max_tokens=4096,
+            )
+            # No exception means preflight succeeded.
+            backend.preflight_model(config, timeout=5)
+
+        assert len(captured_headers) == 2
+        assert captured_headers[0].get("x-api-key") == "jwt-token"
+        assert captured_headers[1].get("Authorization") == "Bearer jwt-token"
+        assert backend._use_bearer is True
+
+    def test_preflight_403_then_401_raises_scorer_error_with_both_bodies(self):
+        import os
+
+        import httpx
+
+        from belt.errors import ScorerError
+        from belt.scorer.entities import JudgeConfig
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        request = httpx.Request("GET", "https://gw.example/anthropic/v1/models/claude-sonnet-4-5")
+        resp_403 = httpx.Response(403, request=request, text="primary-body")
+        resp_401 = httpx.Response(401, request=request, text="retry-body")
+
+        call_count = [0]
+
+        def fake_get(url, headers, timeout):
+            call_count[0] += 1
+            return resp_403 if call_count[0] == 1 else resp_401
+
+        backend = AnthropicBackend()
+        env = {"BELT_ANTHROPIC_API_KEY": "tok", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        patch_env = patch.dict(os.environ, env, clear=False)
+        patch_get = patch("belt.scorer.llm.backend.httpx.get", side_effect=fake_get)
+        with patch_env, patch_get:
+            config = JudgeConfig(model="anthropic/claude-sonnet-4-5", temperature=0.0, seed=0, max_tokens=4096)
+            with pytest.raises(ScorerError) as exc_info:
+                backend.preflight_model(config, timeout=5)
+
+        msg = str(exc_info.value)
+        assert "403+401" in msg
+        assert "primary-body" in msg
+        assert "retry-body" in msg
+
+    def test_preflight_403_then_5xx_returns_silently(self):
+        import os
+
+        import httpx
+
+        from belt.scorer.entities import JudgeConfig
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        request = httpx.Request("GET", "https://gw.example/anthropic/v1/models/claude-sonnet-4-5")
+        resp_403 = httpx.Response(403, request=request, text="auth-err")
+        resp_503 = httpx.Response(503, request=request, text="service-unavailable")
+
+        call_count = [0]
+
+        def fake_get(url, headers, timeout):
+            call_count[0] += 1
+            return resp_403 if call_count[0] == 1 else resp_503
+
+        backend = AnthropicBackend()
+        env = {"BELT_ANTHROPIC_API_KEY": "tok", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        patch_env = patch.dict(os.environ, env, clear=False)
+        patch_get = patch("belt.scorer.llm.backend.httpx.get", side_effect=fake_get)
+        with patch_env, patch_get:
+            config = JudgeConfig(model="anthropic/claude-sonnet-4-5", temperature=0.0, seed=0, max_tokens=4096)
+            # 5xx on retry → transient, should return silently
+            backend.preflight_model(config, timeout=5)
+
+        assert call_count[0] == 2
+
+    def test_preflight_403_then_timeout_returns_silently(self):
+        import os
+
+        import httpx
+
+        from belt.scorer.entities import JudgeConfig
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        request = httpx.Request("GET", "https://gw.example/anthropic/v1/models/claude-sonnet-4-5")
+        resp_403 = httpx.Response(403, request=request, text="auth-err")
+
+        call_count = [0]
+
+        def fake_get(url, headers, timeout):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return resp_403
+            raise httpx.TimeoutException("timed out", request=request)
+
+        backend = AnthropicBackend()
+        env = {"BELT_ANTHROPIC_API_KEY": "tok", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        patch_env = patch.dict(os.environ, env, clear=False)
+        patch_get = patch("belt.scorer.llm.backend.httpx.get", side_effect=fake_get)
+        with patch_env, patch_get:
+            config = JudgeConfig(model="anthropic/claude-sonnet-4-5", temperature=0.0, seed=0, max_tokens=4096)
+            # Timeout on retry → transient, should return silently
+            backend.preflight_model(config, timeout=5)
+
+        assert call_count[0] == 2
+
+    def test_preflight_403_no_retry_headers_raises_scorer_error_with_primary_body(self):
+        """auth_retry_headers returning None (non-Anthropic backend) raises immediately."""
+        import os
+
+        import httpx
+
+        from belt.errors import ScorerError
+        from belt.scorer.entities import JudgeConfig
+        from belt.scorer.llm.backend import OpenAIBackend
+
+        request = httpx.Request("GET", "https://api.openai.com/v1/models/gpt-4.1")
+        resp_403 = httpx.Response(403, request=request, text="openai-403-body")
+
+        def fake_get(url, headers, timeout):
+            return resp_403
+
+        env = {
+            "BELT_OPENAI_API_KEY": "sk-test",
+            "BELT_OPENAI_BASE_URL": "https://api.openai.com",
+        }
+        patch_env = patch.dict(os.environ, env, clear=False)
+        patch_get = patch("belt.scorer.llm.backend.httpx.get", side_effect=fake_get)
+        with patch_env, patch_get:
+            backend = OpenAIBackend()
+            config = JudgeConfig(model="openai/gpt-4.1", temperature=0.0, seed=0, max_tokens=4096)
+            with pytest.raises(ScorerError) as exc_info:
+                backend.preflight_model(config, timeout=5)
+
+        msg = str(exc_info.value)
+        assert "openai-403-body" in msg
+        # Only one attempt — no retry
+        assert "+" not in msg.split("HTTP")[1].split("\n")[0]
+
+    def test_preflight_404_does_not_retry_and_aborts_with_model_hint(self):
+        """A 404 (wrong model name) must NOT trigger an auth retry — it is a
+        config bug, not an auth failure. The abort reports a single HTTP 404
+        and never the misleading 'auth retry didn't help' message."""
+        import os
+
+        import httpx
+
+        from belt.errors import ScorerError
+        from belt.scorer.entities import JudgeConfig
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        request = httpx.Request("GET", "https://gw.example/anthropic/v1/models/does-not-exist")
+        resp_404 = httpx.Response(404, request=request, text="model not found")
+
+        call_count = [0]
+
+        def fake_get(url, headers, timeout):
+            call_count[0] += 1
+            return resp_404
+
+        backend = AnthropicBackend()
+        env = {"BELT_ANTHROPIC_API_KEY": "tok", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        patch_env = patch.dict(os.environ, env, clear=False)
+        patch_get = patch("belt.scorer.llm.backend.httpx.get", side_effect=fake_get)
+        with patch_env, patch_get:
+            config = JudgeConfig(model="anthropic/does-not-exist", temperature=0.0, seed=0, max_tokens=4096)
+            with pytest.raises(ScorerError) as exc_info:
+                backend.preflight_model(config, timeout=5)
+
+        # Exactly one GET — the Bearer auth retry must not fire on a 404.
+        assert call_count[0] == 1
+        assert backend._use_bearer is False
+        msg = str(exc_info.value)
+        assert "HTTP 404" in msg
+        assert "auth retry didn't help" not in msg
+        assert "404+" not in msg
+
+    def test_preflight_403_then_429_returns_silently(self):
+        """A 429 on the auth retry is transient — proceed and let the runtime
+        judge-infra path handle real failures, mirroring the primary attempt."""
+        import os
+
+        import httpx
+
+        from belt.scorer.entities import JudgeConfig
+        from belt.scorer.llm.backend import AnthropicBackend
+
+        request = httpx.Request("GET", "https://gw.example/anthropic/v1/models/claude-sonnet-4-5")
+        resp_403 = httpx.Response(403, request=request, text="auth-err")
+        resp_429 = httpx.Response(429, request=request, text="rate-limited")
+
+        call_count = [0]
+
+        def fake_get(url, headers, timeout):
+            call_count[0] += 1
+            return resp_403 if call_count[0] == 1 else resp_429
+
+        backend = AnthropicBackend()
+        env = {"BELT_ANTHROPIC_API_KEY": "tok", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        patch_env = patch.dict(os.environ, env, clear=False)
+        patch_get = patch("belt.scorer.llm.backend.httpx.get", side_effect=fake_get)
+        with patch_env, patch_get:
+            config = JudgeConfig(model="anthropic/claude-sonnet-4-5", temperature=0.0, seed=0, max_tokens=4096)
+            # 429 on retry → transient, should return silently
+            backend.preflight_model(config, timeout=5)
+
+        assert call_count[0] == 2

--- a/tests/scorer/llm/test_scorer.py
+++ b/tests/scorer/llm/test_scorer.py
@@ -1067,3 +1067,226 @@ class TestOllamaResponseParsing:
         assert usage is not None
         assert usage["prompt_tokens"] == 200
         assert usage["completion_tokens"] == 75
+
+
+class TestJudgeRetryWithBearer:
+    """403 with x-api-key triggers one retry with Authorization: Bearer."""
+
+    def _make_responses(self):
+        """First call:403 (WAF). Second call: 200 with a valid verdict."""
+        request = httpx.Request("POST", "https://gw.example/anthropic/v1/messages")
+        resp_403 = httpx.Response(
+            403,
+            request=request,
+            text="<H1>403 ERROR</H1><H2>The request could not be satisfied",
+        )
+        resp_200 = httpx.Response(
+            200,
+            request=request,
+            json={
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "judge_verdict",
+                        "input": {"overall_pass": True},
+                    }
+                ],
+                "model": "claude-sonnet-4-5",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+        return resp_403, resp_200
+
+    def test_403_with_x_api_key_retries_with_bearer_and_succeeds(self):
+        import os
+        from unittest.mock import patch
+
+        from belt.entities import JudgeConfig
+        from belt.scorer.llm.backend import AnthropicBackend
+        from belt.scorer.llm.scorer import LLMScorer
+
+        resp_403, resp_200 = self._make_responses()
+        backend = AnthropicBackend()
+        captured_headers: list[dict[str, str]] = []
+
+        def fake_post(url, json, headers, timeout):
+            captured_headers.append(dict(headers))
+            if len(captured_headers) == 1:
+                return resp_403
+            return resp_200
+
+        env = {
+            "BELT_ANTHROPIC_API_KEY": "jwt-token",
+            "BELT_ANTHROPIC_BASE_URL": "https://gw.example",
+        }
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch("belt.scorer.llm.scorer.httpx.post", side_effect=fake_post),
+        ):
+            config = JudgeConfig(
+                model="anthropic/claude-sonnet-4-5",
+                temperature=0.0,
+                seed=2008,
+                max_tokens=4096,
+            )
+            scorer = LLMScorer(
+                config=config,
+                backend=backend,
+                cache=None,
+                max_retries=1,
+                skip_availability=True,
+            )
+            verdict, _usage = scorer._call_api(
+                system_message="judge",
+                dynamic_msg="go",
+            )
+
+        assert len(captured_headers) == 2
+        assert captured_headers[0].get("x-api-key") == "jwt-token"
+        assert "Authorization" not in captured_headers[0]
+        assert captured_headers[1].get("Authorization") == "Bearer jwt-token"
+        assert "x-api-key" not in captured_headers[1]
+        assert backend._use_bearer is True
+        assert verdict is not None
+        assert verdict.overall_pass is True
+
+    def test_403_then_401_retry_raises_scorer_error_with_both_bodies(self):
+        """403 primary +401 retry → ScorerError that includes both response bodies."""
+        import os
+        from unittest.mock import patch
+
+        from belt.entities import JudgeConfig
+        from belt.errors import ScorerError
+        from belt.scorer.llm.backend import AnthropicBackend
+        from belt.scorer.llm.scorer import LLMScorer
+
+        request = httpx.Request("POST", "https://gw.example/anthropic/v1/messages")
+        resp_403 = httpx.Response(403, request=request, text="primary-body-403")
+        resp_401 = httpx.Response(401, request=request, text="retry-body-401")
+
+        call_count = 0
+
+        def fake_post(url, json, headers, timeout):
+            nonlocal call_count
+            call_count += 1
+            return resp_403 if call_count == 1 else resp_401
+
+        backend = AnthropicBackend()
+        env = {"BELT_ANTHROPIC_API_KEY": "jwt-token", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        config = JudgeConfig(model="anthropic/claude-sonnet-4-5", temperature=0.0, seed=0, max_tokens=4096)
+        post_patch = patch("belt.scorer.llm.scorer.httpx.post", side_effect=fake_post)
+        with patch.dict(os.environ, env, clear=False), post_patch:
+            scorer = LLMScorer(config=config, backend=backend, cache=None, max_retries=1, skip_availability=True)
+            with pytest.raises(ScorerError) as exc_info:
+                scorer._call_api(system_message="judge", dynamic_msg="go")
+
+        msg = str(exc_info.value)
+        assert "403" in msg
+        assert "401" in msg
+        assert "primary-body-403" in msg
+        assert "retry-body-401" in msg
+        assert "auth retry" in msg.lower()
+
+    def test_403_then_500_retry_raises_judge_infra_error(self):
+        """403 primary + 5xx retry → JudgeInfraError('other'), not ScorerError."""
+        import os
+        from unittest.mock import patch
+
+        from belt.entities import JudgeConfig
+        from belt.errors import JudgeInfraError
+        from belt.scorer.llm.backend import AnthropicBackend
+        from belt.scorer.llm.scorer import LLMScorer
+
+        request = httpx.Request("POST", "https://gw.example/anthropic/v1/messages")
+        resp_403 = httpx.Response(403, request=request, text="waf-403")
+        resp_500 = httpx.Response(500, request=request, text="internal-error")
+
+        call_count = 0
+
+        def fake_post(url, json, headers, timeout):
+            nonlocal call_count
+            call_count += 1
+            return resp_403 if call_count == 1 else resp_500
+
+        backend = AnthropicBackend()
+        env = {"BELT_ANTHROPIC_API_KEY": "jwt-token", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        config = JudgeConfig(model="anthropic/claude-sonnet-4-5", temperature=0.0, seed=0, max_tokens=4096)
+        post_patch = patch("belt.scorer.llm.scorer.httpx.post", side_effect=fake_post)
+        with patch.dict(os.environ, env, clear=False), post_patch:
+            scorer = LLMScorer(config=config, backend=backend, cache=None, max_retries=1, skip_availability=True)
+            with pytest.raises(JudgeInfraError) as exc_info:
+                scorer._call_api(system_message="judge", dynamic_msg="go")
+
+        assert exc_info.value.error_type == "other"
+
+    def test_403_then_timeout_on_retry_raises_judge_infra_error(self):
+        """403 primary + timeout on retry → JudgeInfraError('timeout')."""
+        import os
+        from unittest.mock import patch
+
+        from belt.entities import JudgeConfig
+        from belt.errors import JudgeInfraError
+        from belt.scorer.llm.backend import AnthropicBackend
+        from belt.scorer.llm.scorer import LLMScorer
+
+        request = httpx.Request("POST", "https://gw.example/anthropic/v1/messages")
+        resp_403 = httpx.Response(403, request=request, text="waf-403")
+
+        call_count = 0
+
+        def fake_post(url, json, headers, timeout):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return resp_403
+            raise httpx.ReadTimeout("timed out", request=request)
+
+        backend = AnthropicBackend()
+        env = {"BELT_ANTHROPIC_API_KEY": "jwt-token", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        config = JudgeConfig(model="anthropic/claude-sonnet-4-5", temperature=0.0, seed=0, max_tokens=4096)
+        post_patch = patch("belt.scorer.llm.scorer.httpx.post", side_effect=fake_post)
+        with patch.dict(os.environ, env, clear=False), post_patch:
+            scorer = LLMScorer(config=config, backend=backend, cache=None, max_retries=1, skip_availability=True)
+            with pytest.raises(JudgeInfraError) as exc_info:
+                scorer._call_api(system_message="judge", dynamic_msg="go")
+
+        assert exc_info.value.error_type == "timeout"
+
+    def test_use_bearer_true_skips_retry(self):
+        """Once _use_bearer=True, build_request emits Bearer; a 403 does not trigger a second retry."""
+        import os
+        from unittest.mock import patch
+
+        from belt.entities import JudgeConfig
+        from belt.errors import ScorerError
+        from belt.scorer.llm.backend import AnthropicBackend
+        from belt.scorer.llm.scorer import LLMScorer
+
+        request = httpx.Request("POST", "https://gw.example/anthropic/v1/messages")
+        resp_403 = httpx.Response(403, request=request, text="still-403")
+
+        captured_headers: list[dict] = []
+
+        def fake_post(url, json, headers, timeout):
+            captured_headers.append(dict(headers))
+            return resp_403
+
+        backend = AnthropicBackend()
+        backend.record_auth_retry_success()  # pre-set: Bearer is the cached style
+        env = {"BELT_ANTHROPIC_API_KEY": "jwt-token", "BELT_ANTHROPIC_BASE_URL": "https://gw.example"}
+        config = JudgeConfig(model="anthropic/claude-sonnet-4-5", temperature=0.0, seed=0, max_tokens=4096)
+        post_patch = patch("belt.scorer.llm.scorer.httpx.post", side_effect=fake_post)
+        with patch.dict(os.environ, env, clear=False), post_patch:
+            scorer = LLMScorer(config=config, backend=backend, cache=None, max_retries=1, skip_availability=True)
+            with pytest.raises(ScorerError):
+                scorer._call_api(system_message="judge", dynamic_msg="go")
+
+        # build_request already used Bearer; auth_retry_headers returns None
+        # (no x-api-key in original headers) → only one POST was made.
+        assert len(captured_headers) == 1
+        assert captured_headers[0].get("Authorization") == "Bearer jwt-token"
+        assert "x-api-key" not in captured_headers[0]


### PR DESCRIPTION
Closes #2

## Summary

- Adds an opt-in `auth_retry_headers` hook to `BaseJudgeBackend` (default `None`); only `AnthropicBackend` overrides it, swapping `x-api-key` → `Authorization: Bearer <key>` on retry.
- The judge POST dispatcher (`LLMScorer._call_api`) and the preflight GET (`_do_get_preflight`) retry once with the fallback headers on a 401/403, then cache the working auth style for the rest of the run.
- A 404 (wrong model name) does not trigger the retry; non-auth failures (5xx/429/timeout/network) stay transient. Other backends are unchanged (default hook returns `None`).

## Why

Some gateways in front of the Anthropic API (e.g. JFrog's LLM gateway WAF) reject `x-api-key` from certain egress IPs with a 403 while accepting an identical `Authorization: Bearer`. Anthropic's own API also accepts Bearer, so the fallback is safe in and out of that environment.

## Tests

Unit + integration coverage for every retry branch on both the dispatcher and preflight (403 → 200 / 401 / 404 / 5xx / timeout / 429), backends with no fallback, and the cached-Bearer path skipping the retry on subsequent calls.
