### PR TITLE
docs(sandboxing): list SANDBOXING.md in README; fix cross-refs and non-root claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ file, no duplication:
 | Scenario authoring + JSON schema reference | [SCENARIOS.md](docs/glossary/SCENARIOS.md) |
 | Scoring (rules + LLM judges, multi-judge, thresholds) | [SCORING.md](docs/glossary/SCORING.md) |
 | Layered configuration, env vars, security toggles | [CONFIGURATION.md](docs/glossary/CONFIGURATION.md) |
+| Sandbox providers, kernel invariants, network policy | [SANDBOXING.md](docs/glossary/SANDBOXING.md) |
 | CLI subcommand index, workflows, progress modes | [CLI.md](docs/glossary/CLI.md) |
 | CI integration, threshold gating, agent install/auth recipes | [CI.md](docs/glossary/CI.md) |
 | Plugin architecture (agents, scorers, exporters) | [PLUGGABILITY.md](docs/glossary/PLUGGABILITY.md) |

--- a/docs/glossary/SANDBOXING.md
+++ b/docs/glossary/SANDBOXING.md
@@ -14,7 +14,7 @@ available on the current host.
 |---|---|---|
 | `host` | [`src/belt/runner/sandbox/host.py`](../../src/belt/runner/sandbox/host.py) | None. The agent runs as the invoking user with the user's `$PATH`, full filesystem access, and unrestricted network. |
 | `docker` | [`src/belt/runner/sandbox/docker.py`](../../src/belt/runner/sandbox/docker.py) | Containerised. The kernel-enforced invariants are listed in §2. |
-| Third-party | `belt.sandbox_providers` entry-point group; see [PLUGGABILITY.md §9](PLUGGABILITY.md#9-authoring-a-sandbox-provider) | Provider-defined. Validation against `SandboxProfile` is the provider's responsibility. |
+| Third-party | `belt.sandbox_providers` entry-point group; see [PLUGGABILITY.md §10](PLUGGABILITY.md#10-authoring-a-sandbox-provider) | Provider-defined. Validation against `SandboxProfile` is the provider's responsibility. |
 
 ## 2. Kernel-enforced invariants under `--sandbox docker`
 
@@ -27,7 +27,7 @@ container; the `skipif` guard auto-skips when docker is not installed.
 | Capability drop | `--cap-drop=ALL`, `--security-opt=no-new-privileges` | `tests/runner/sandbox/test_docker_e2e.py::test_e2e_capability_dropped_mount_blocked` |
 | Read-only rootfs | `--read-only` (with tmpfs `$HOME` for transient writes) | `test_e2e_rootfs_is_readonly_writes_to_etc_fail` |
 | Filesystem scope | Bind-mounts the per-scenario worktree and the scenario-declared `writable_paths` only | `test_e2e_writes_outside_worktree_and_extras_fail` |
-| Non-root user | `--user 1000:1000` | `test_e2e_runs_as_unprivileged_user_not_root` |
+| Non-root user | Sandbox image declares a non-root `USER` (reference image: `USER belt`, uid 1000); the runner never overrides it back to root | `test_e2e_runs_as_unprivileged_user_not_root` |
 | Network isolation | `network_policy: "none"` → `--network=none` (outbound TCP and DNS fail at the kernel with `EHOSTUNREACH` / `ENETUNREACH`) | `test_e2e_network_policy_none_blocks_outbound_tcp_at_kernel_level`, `test_e2e_network_policy_none_blocks_dns_resolution` |
 | Env passthrough | Exact-name allowlist (`SandboxProfile.env_passthrough` ∪ the agent's declared required env); no wildcards, no shell expansion | `test_e2e_env_not_in_passthrough_does_not_leak`, `test_e2e_env_passthrough_value_delivered_when_listed` |
 | Dangerous-flag denylist | Per-agent `denied_flags()` blocks `--yolo`, `--dangerously-skip-permissions`, `--sandbox=danger-full-access`, `--allow-all*`, etc. Enforced before the sandbox layer, so it applies on every provider including `host`. | `tests/test_security.py::TestAgentDeniedFlagsDefaults` |
@@ -52,4 +52,4 @@ Per-group fields take precedence over `BELT_SANDBOX_PROVIDER` and the
 
 ## 5. Authoring a provider
 
-See [PLUGGABILITY.md §9](PLUGGABILITY.md#9-authoring-a-sandbox-provider).
+See [PLUGGABILITY.md §10](PLUGGABILITY.md#10-authoring-a-sandbox-provider).

--- a/src/belt/runner/sandbox/docker.py
+++ b/src/belt/runner/sandbox/docker.py
@@ -11,8 +11,10 @@ Implementation choices and their rationale:
   parsing of ``docker``'s exit codes; the benefit is zero new dependencies.
 - **Filesystem + capability isolation are first-class.** The wrapper sets
   ``--cap-drop=ALL``, ``--security-opt=no-new-privileges``, ``--read-only``
-  rootfs, ``--user 1000:1000``, and bind-mounts only the worktree (plus
-  scenario-declared ``writable_paths``). An agent inside the container
+  rootfs, runs as the image's non-root ``USER`` (the reference image
+  declares ``USER belt``, uid 1000; the runner never overrides it back to
+  root), and bind-mounts only the worktree (plus scenario-declared
+  ``writable_paths``). An agent inside the container
   cannot read ``$HOME`` on the host, cannot escalate, cannot mount, cannot
   ptrace, cannot write outside the worktree.
 - **Network policy has two kernel-enforced modes plus a v1 hint.**

--- a/tests/runner/sandbox/test_docker_e2e.py
+++ b/tests/runner/sandbox/test_docker_e2e.py
@@ -249,12 +249,10 @@ def test_e2e_writes_outside_worktree_and_extras_fail(tmp_path: Path) -> None:
 
 
 def test_e2e_runs_as_unprivileged_user_not_root(tmp_path: Path) -> None:
-    # The reference image declares ``USER belt`` (uid 1000); the runner
-    # does not currently override it (the docstring mentions
-    # ``--user 1000:1000`` belt-and-suspenders, but the canonical
-    # source of truth is the image USER). Either way, the container
-    # MUST NOT run as root -- a regression that drops USER from the
-    # image or adds ``--user 0`` to the runner would break this.
+    # Non-root is enforced by the image's ``USER belt`` (uid 1000), not by
+    # the runner -- the runner never passes ``--user``. The container MUST
+    # NOT run as root: a regression that drops ``USER`` from the image or
+    # adds ``--user 0`` to the runner would break this.
     result = _run_in_sandbox(tmp_path, "import os; print(os.getuid())")
     assert result.returncode == 0, result.stderr
     uid = int(result.stdout.strip())


### PR DESCRIPTION
## Summary

Documentation accuracy fixes for the docker sandbox, verified against the code.

- **README**: add the missing `SANDBOXING.md` row to the glossary table — it was the only one of the glossary docs not linked from the top-level README.
- **Non-root claim corrected** in three places — `SANDBOXING.md` §2, the `docker.py` module docstring, and the `test_e2e_runs_as_unprivileged_user_not_root` comment. They claimed non-root is enforced via `--user 1000:1000`, but the runner never passes `--user`. Non-root comes from the sandbox image's `USER belt` (uid 1000), which the e2e test actually asserts (`uid != 0`).
- **Cross-refs**: `SANDBOXING.md` PLUGGABILITY links updated §9 → §10 to track the sandbox-provider section's new number after the `BaseJudgeBackend` section landed on `main`.

## Verification

- `wrap()` in `docker.py` builds the docker argv with no `--user` flag (read in full).
- Reference images declare `USER belt` / uid 1000 (`Dockerfile.generic`, `Dockerfile.cursor.example`).
- PLUGGABILITY.md section numbering confirmed: §9 = exporter, §10 = sandbox provider.
- `ruff` / `black` / `isort` clean; `scripts/check_design.py` 10/10; `tests/runner/sandbox/test_docker_e2e.py` — 23 passed (docker present).
