### PR TITLE
feat(scorer): deterministic verify step (run a command, assert exit code)

### DIFF
--- a/docs/glossary/CONFIGURATION.md
+++ b/docs/glossary/CONFIGURATION.md
@@ -125,6 +125,7 @@ flag (CLI wins over env).
 | `BELT_ALLOW_INSECURE_BASE_URL` |
 | `BELT_ALLOW_FULL_ENV` |
 | `BELT_ALLOW_INPLACE` |
+| `BELT_ALLOW_VERIFY_EXEC` |
 | `BELT_ALLOW_ARBITRARY_AGENT` |
 | `BELT_ALLOW_ARBITRARY_SCORER` |
 | `BELT_ALLOW_ARBITRARY_EXPORTER` |
@@ -185,6 +186,7 @@ matching `BELT_ALLOW_*` env var) opts in for that invocation.
 | `--allow-arbitrary-exporter` | `eval`, `export` | Loading an exporter via dotted import path. | Same as above, for an exporter not yet registered as an `belt.exporters` entry point. |
 | `--allow-external-working-dir` | `eval`, `run` | Allowing a scenario's `working_dir` to resolve outside the scenarios-root path argument. | Multi-repo monorepos where scenarios deliberately reference a sibling worktree. |
 | `--allow-inplace` | `eval`, `run` | Permitting groups whose `_config.json` declares `workspace_isolation: "none"`. Default DENY: belt refuses such groups so an agent never runs without per-scenario worktree isolation by accident. The schema rejects any other value than `git-worktree` / `none` at parse time, so this gate is the *only* way isolation gets disabled. | Scenarios that deliberately edit the harness CWD (rare; usually you want `git-worktree`). |
+| `--allow-verify-exec` | `eval`, `run` | Permitting scenarios that declare a `verify` command (deterministic exec-test grading). Default DENY: belt refuses such groups at setup because `verify` runs an author-supplied command in the worktree. Requires an isolated worktree. | Code-editing scenarios that gate on the project's own test suite (e.g. `python -m pytest`). |
 
 > **Per-agent denied flags.** Each agent declares a `denied_flags()`
 > set (e.g. `--dangerously-skip-permissions` on Claude Code) that the

--- a/docs/glossary/OUTCOMES.md
+++ b/docs/glossary/OUTCOMES.md
@@ -48,6 +48,15 @@ are internal inputs to the benchmark card; their fields are absorbed
 into the versioned card and never surface independently to external
 readers.
 
+When a scenario declares a `verify` command (see
+[SCENARIOS.md → §4.3](SCENARIOS.md#43-verify-deterministic-exec-test)),
+`turn_N_output.json` carries the captured `VerifyResult`
+(`{cmd, exit_code, stdout, duration_s}`) under `verify_result` (per-turn) and,
+on the final turn, `scenario_verify_result` (per-scenario). `cmd` is stored so
+the artifact is self-describing (a reader sees *what* ran) and every renderer
+(`belt view`, the results panel) can show the command without re-reading the
+scenario. The rule-based scorer reads these into the `verify` dimension.
+
 ### 2.1. Nested scorer payloads inside `score.json`
 
 `score.json` carries an outer `schema_version` for the `ScenarioScore`

--- a/docs/glossary/SCENARIOS.md
+++ b/docs/glossary/SCENARIOS.md
@@ -128,6 +128,7 @@ Minimum:
 | `flags` | No | `[]` | Extra CLI flags forwarded to `agent.execute()`. |
 | `expect` | No | `{}` | Deterministic rule-based expectations. See [§4](#4-turn-expect-and-state_expect). |
 | `state_expect` | No | `{}` | Post-turn workspace filesystem checks. See [§4.2](#42-state_expect). |
+| `verify` | No | `null` | Deterministic command run after this turn in the worktree. See [§4.3](#43-verify-deterministic-exec-test). |
 
 ## 4. Turn `expect` and `state_expect`
 
@@ -200,6 +201,34 @@ LLM judge as ground-truth evidence.
 | `files_exist` / `files_not_exist` | list[str] | `[]` | Relative paths that must / must not exist after the turn. |
 | `files_contain` | dict[str, str] | `{}` | Path → substring required in file content. |
 | `capture_git_diff` | bool | `false` | Capture `git diff` into `TurnOutput.raw_state`. |
+
+### 4.3. `verify` (deterministic exec-test)
+
+`verify` runs an author-declared command in the worktree and gates on its
+exit code - the strongest, cheapest grader for code-editing scenarios ("did
+the agent's change make the test suite pass?"). Declarable on a **turn**
+(`Turn.verify`, runs after that turn) or on the **scenario**
+(`Scenario.verify`, runs once after the final turn - the end-of-conversation
+case). Both produce checks under the `rules/verify` dimension; a skipped
+verify (command did not run) is recorded as a tri-state skip, not a failure.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `cmd` | list[str] | - | Command argv (no shell). E.g. `["python", "-m", "pytest", "-q"]`. |
+| `exit_code` | int | `0` | Expected exit code; the check passes when it matches. |
+| `output_contains` | list[str] | `[]` | Plain substrings (not regex) that must all appear in stdout. |
+| `timeout` | int | `300` | Max seconds; a timeout fails the check. |
+
+```json
+"verify": { "cmd": ["python", "-m", "pytest", "-q"], "exit_code": 0, "output_contains": ["passed"] }
+```
+
+`verify` executes an author-supplied command, so it is default-deny: it runs
+only with an isolated worktree and only when `--allow-verify-exec` (or
+`BELT_ALLOW_VERIFY_EXEC=1`) is set; otherwise the group is refused at setup.
+The command runs through the active sandbox provider (inside the container
+under `--sandbox docker`) with a minimal, credential-free environment. See
+[SECURITY-MODEL.md](SECURITY-MODEL.md#511-deterministic-verify-execution).
 
 ## 5. Multi-turn templating
 

--- a/docs/glossary/SCORING.md
+++ b/docs/glossary/SCORING.md
@@ -36,6 +36,7 @@ keys that contribute to it. The on-disk `expect` shape lives in
 | `state` | `files_exist`, `files_contain`, `files_not_exist` |
 | `file_diff` | `files_modified_any`, `files_modified_exact`, `files_not_modified`, `git_diff_contains` |
 | `performance` | `max_ttfe_seconds`, `max_ttft_seconds`, `max_ttlt_seconds`, `max_total_seconds` |
+| `verify` | `Turn.verify` / `Scenario.verify` (deterministic command exit code + `output_contains`); see [SCENARIOS.md → §4.3](SCENARIOS.md#43-verify-deterministic-exec-test) |
 
 Each check produces a
 `CheckEntry(dimension, check, passed, details, turn_idx)` - full

--- a/docs/glossary/SECURITY-MODEL.md
+++ b/docs/glossary/SECURITY-MODEL.md
@@ -138,6 +138,7 @@ mitigation and the test that pins it. `S`poofing, `T`ampering,
 | T12 | A hostile config imports an arbitrary Python module as an "agent" | T,E | dotted-path import is default-deny behind `--allow-arbitrary-agent` (same for scorer / exporter) | `TestArbitraryRegistryGating` |
 | T13 | PID reuse makes orphan cleanup delete a live run's resources | T | manifest records process create-time and compares it on liveness checks | `TestPidCreateTime`, `TestManifestHardening` |
 | T14 | World-readable artifacts leak transcripts / caches on a shared host | I | `0o077` umask plus explicit `0o700` / `0o600` on run dirs, caches, and the manifest | `TestUmask`, `TestRunDirectoryPermissions` |
+| T15 | A scenario's `verify` command executes arbitrary code on the host | E,I | default-deny `--allow-verify-exec`; runs only with an isolated worktree, through the sandbox provider, with a minimal (credential-free) env, bounded output, and a timeout | `tests/scorer/rules/test_verify.py` (`TestVerifyGate`, `TestRunVerifyCommand`) |
 
 ## 5. Control catalog by domain
 
@@ -293,6 +294,32 @@ whole tree without reaching back to `belt`.
 [`agent/base.py`](../../src/belt/agent/base.py)). **Pinned by**
 `TestManifestHardening`, `TestPidCreateTime`, `TestKillProcessTree`.
 
+### 5.11. Deterministic verify execution
+
+A scenario may declare a `verify` command (`Turn.verify` / `Scenario.verify`)
+that the runner executes after a turn / after the conversation to grade
+deterministically (e.g. run the project's test suite and assert exit 0). This
+is the one place the runner executes an author-supplied command rather than
+the agent, so it carries the full control set: default-deny behind
+`--allow-verify-exec` (the group is refused at setup otherwise), runs only
+with an isolated worktree, routes through the same `spawner` as the agent (so
+it lands inside the container under `--sandbox docker`), gets a minimal
+credential-free environment (`build_subprocess_env()` base set), captures
+stdout under a byte cap, and is bounded by a per-spec `timeout` with a
+process-group kill on expiry. `cmd` is an argv list (never a shell string);
+`output_contains` are plain substrings. Captured stdout is untrusted command
+output, so it is ANSI/OSC-stripped at capture (no terminal-escape sequence can
+reach a renderer or split a match), and on failure only a sanitized,
+length-capped tail is surfaced in the report `details`. The stored
+`verify_result` (including `cmd`, kept so the artifact is self-describing) is
+rendered through `belt view`'s existing `TurnOutput` surface, which markup-escapes
+at the sink (P8) — its stdout is already control-stripped, so no new raw sink is
+introduced. The result is scored as
+the `verify` dimension. ([`runner/orchestrator.py`](../../src/belt/runner/orchestrator.py),
+[`runner/phases/setup_groups.py`](../../src/belt/runner/phases/setup_groups.py),
+[`scorer/rules/verify.py`](../../src/belt/scorer/rules/verify.py)). **Pinned
+by** `tests/scorer/rules/test_verify.py`.
+
 ## 6. Default-deny behaviour gates
 
 Every gate that lowers a boundary is off by default and needs an
@@ -309,6 +336,7 @@ the risk framing:
 | `--allow-inplace` | Scenarios run without per-scenario worktree isolation, directly in the working directory. |
 | `--allow-external-working-dir` | A scenario's `working_dir` may resolve outside the scenarios root. |
 | `--allow-arbitrary-agent` / `-scorer` / `-exporter` | A dotted import path is loaded, executing arbitrary module code at process start. |
+| `--allow-verify-exec` | A scenario's `verify` command (an author-supplied argv) runs in the worktree. Mitigated by worktree isolation, sandbox routing, a credential-free env, output caps, and a timeout - but it is still command execution from scenario data. |
 
 Only the canonical truthy tokens (`1`, `true`, `yes`) enable a gate; a
 typo such as `TRUE` or `0` leaves it closed, so a malformed value

--- a/examples/fixtures/tasktracker/pyproject.toml
+++ b/examples/fixtures/tasktracker/pyproject.toml
@@ -9,3 +9,4 @@ tasktracker = "tasktracker.cli:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]

--- a/examples/scenarios/showcase/verify/_config.json
+++ b/examples/scenarios/showcase/verify/_config.json
@@ -1,0 +1,7 @@
+{
+  "agent": "cursor",
+  "working_dir": "../../../fixtures/tasktracker",
+  "workspace_isolation": "git-worktree",
+  "workspace_ref": "HEAD",
+  "default_tags": ["showcase", "verify"]
+}

--- a/examples/scenarios/showcase/verify/verify_per_scenario.json
+++ b/examples/scenarios/showcase/verify/verify_per_scenario.json
@@ -1,0 +1,20 @@
+{
+  "name": "verify_per_scenario",
+  "description": "Per-scenario `verify` (end-of-conversation): a multi-turn conversation plays out, then the runner runs the fixture's pytest suite once at the end and asserts exit 0. Demonstrates running deterministic verification after a full user-and-agent exchange rather than after each turn. Requires --allow-verify-exec.",
+  "tags": ["showcase", "verify", "multi-turn", "real-runnable"],
+  "turns": [
+    {
+      "message": "Briefly summarize what the tasktracker package does, based on the source under src/tasktracker/.",
+      "expect": {"no_errors": true, "has_reply": true}
+    },
+    {
+      "message": "Now add a short module-level docstring to src/tasktracker/storage.py describing its responsibility. Do not change behavior or any other file.",
+      "expect": {"no_errors": true, "has_reply": true}
+    }
+  ],
+  "verify": {
+    "cmd": ["python", "-m", "pytest", "-q"],
+    "exit_code": 0,
+    "output_contains": ["passed"]
+  }
+}

--- a/examples/scenarios/showcase/verify/verify_per_turn.json
+++ b/examples/scenarios/showcase/verify/verify_per_turn.json
@@ -1,0 +1,19 @@
+{
+  "name": "verify_per_turn",
+  "description": "Per-turn `verify`: after the agent edits the project, the runner runs the fixture's own pytest suite in the worktree and asserts it exits 0 (the rules/verify dimension). Demonstrates deterministic exec-test grading - a green check means the test suite actually passed, not merely that the reply looked right. Requires --allow-verify-exec.",
+  "tags": ["showcase", "verify", "single-turn", "real-runnable"],
+  "turns": [
+    {
+      "message": "Add a concise module-level docstring to src/tasktracker/formatters.py describing what the module does. Do not change any code behavior and do not edit any other file.",
+      "expect": {
+        "no_errors": true,
+        "has_reply": true
+      },
+      "verify": {
+        "cmd": ["python", "-m", "pytest", "-q"],
+        "exit_code": 0,
+        "output_contains": ["passed"]
+      }
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,16 +143,19 @@ packages = ["src/belt"]
 # fixtures, cross-agent demos, or scorer-config snippets that users don't
 # need bundled.
 #
-# The `sample-project` fixture rides along because three showcase groups
-# (editing-workspace, sandboxed, sandboxed-offline) declare
-# `working_dir: "../../../fixtures/sample-project"` in their _config.json.
-# Without it those groups raise `WorkspaceError: working_dir does not exist`
-# at scenario load time. Subpath only (220K); bundling the full
-# `examples/fixtures/` directory would pull in 38MB of bookstore-api /
-# tasktracker / urlshortener fixtures that no showcase group references.
+# Fixtures ride along only when a showcase group references them via
+# `working_dir: "../../../fixtures/<name>"`; otherwise the group raises
+# `WorkspaceError: working_dir does not exist` at scenario load time (and
+# `make verify-wheel` fails the bundled-working_dir check). `sample-project`
+# is referenced by editing-workspace / sandboxed / sandboxed-offline;
+# `tasktracker` by the `verify` showcase (it ships a real pytest suite the
+# verify exec-test grades). Both are tiny text-only subpaths. The remaining
+# `examples/fixtures/` entries (bookstore-api / folio / urlshortener) stay
+# repo-only - they are large and no showcase group references them.
 [tool.hatch.build.targets.wheel.force-include]
 "examples/scenarios/showcase" = "belt/_bundled_examples/scenarios/showcase"
 "examples/fixtures/sample-project" = "belt/_bundled_examples/fixtures/sample-project"
+"examples/fixtures/tasktracker" = "belt/_bundled_examples/fixtures/tasktracker"
 
 # The agent-skills directory at src/belt/.agents/skills/belt/ is shipped
 # automatically by the default package selection above (it lives inside the

--- a/src/belt/commands/eval.py
+++ b/src/belt/commands/eval.py
@@ -200,6 +200,17 @@ def _build_parser() -> argparse.ArgumentParser:
             "Off by default - belt refuses with ConfigError."
         ),
     )
+    exe.add_argument(
+        "--allow-verify-exec",
+        action="store_true",
+        default=False,
+        help=(
+            "Permit scenarios that declare a ``verify`` command (deterministic "
+            "exec-test grading). Off by default - belt refuses such groups at "
+            "setup because verify runs an author-supplied command in the worktree. "
+            "Requires an isolated worktree."
+        ),
+    )
     exe.add_argument("--dry-run", action="store_true", help="List matching scenarios without executing")
     exe.add_argument("--no-cleanup", action="store_true", default=False, help="Skip group teardown after run")
     exe.add_argument(
@@ -488,6 +499,8 @@ def main(argv: list[str] | None = None) -> int:
         run_argv += ["--allow-inplace"]
     if getattr(args, "allow_insecure_base_url", False):
         run_argv += ["--allow-insecure-base-url"]
+    if getattr(args, "allow_verify_exec", False):
+        run_argv += ["--allow-verify-exec"]
     if getattr(args, "sandbox", None):
         run_argv += ["--sandbox", args.sandbox]
 

--- a/src/belt/commands/run.py
+++ b/src/belt/commands/run.py
@@ -212,6 +212,17 @@ def _add_common_run_args(parser: argparse.ArgumentParser) -> None:
             f"{envvars.ALLOW_INSECURE_BASE_URL}=1."
         ),
     )
+    exe.add_argument(
+        "--allow-verify-exec",
+        action="store_true",
+        default=False,
+        help=(
+            "Permit scenarios that declare a ``verify`` command (deterministic "
+            "exec-test grading). Off by default - belt refuses such groups at "
+            "setup because verify runs an author-supplied command in the worktree. "
+            f"Same effect as setting {envvars.ALLOW_VERIFY_EXEC}=1."
+        ),
+    )
     exe.add_argument("--dry-run", action="store_true", help="List matching scenarios without executing")
     exe.add_argument(
         "--no-cleanup", action="store_true", default=False, help="Skip group teardown after run (default: clean up)"

--- a/src/belt/commands/view.py
+++ b/src/belt/commands/view.py
@@ -495,6 +495,30 @@ def _show_turn_detail(con: Console, outcome_dir: Path, turn_idx: int) -> None:
                 lines.append(f"  Error type: {turn_output.error_type}")
             lines.append("")
 
+        # Verify results (deterministic exec-test grader). Shown for both the
+        # per-turn (``verify_result``) and per-scenario (``scenario_verify_result``,
+        # on the final turn) commands so the verification detail - command,
+        # exit code, and stdout tail - is visible here in every progress mode.
+        for label, vr in (
+            ("Verify", turn_output.verify_result),
+            ("Verify (scenario)", turn_output.scenario_verify_result),
+        ):
+            if vr is None:
+                continue
+            cmd_str = " ".join(vr.cmd) or "(command)"
+            dur = f"  ({_fmt_secs(vr.duration_s)})" if vr.duration_s is not None else ""
+            icon = "[green]✅[/green]" if vr.exit_code == 0 else "[red]❌[/red]"
+            lines.append(f"[bold]{label}:[/bold] {icon}")
+            lines.append(("  $ " + cmd_str).replace("[", "\\["))
+            lines.append(f"  exit code: {vr.exit_code}{dur}")
+            tail = (vr.stdout or "").strip()
+            if tail:
+                if len(tail) > 800:
+                    tail = "…\n" + tail[-800:]
+                lines.append("  output (tail):")
+                lines.append(("  " + tail.replace("\n", "\n  ")).replace("[", "\\["))
+            lines.append("")
+
     # CLI output (truncated)
     if cli_text.strip():
         cli_preview = cli_text.strip()

--- a/src/belt/entities.py
+++ b/src/belt/entities.py
@@ -108,6 +108,22 @@ class TurnTiming(BaseModel):
     total: Optional[float] = None
 
 
+class VerifyResult(BaseModel):
+    """Outcome of a ``VerifySpec`` command executed by the runner.
+
+    Captured into :attr:`TurnOutput.verify_result` (per-turn) or
+    :attr:`TurnOutput.scenario_verify_result` (per-scenario, on the final
+    turn) so the rule-based scorer can assert on it without re-executing.
+    ``cmd`` is stored so the artifact and every renderer are self-describing
+    (a reader sees *what* was run, not just the exit code).
+    """
+
+    cmd: list[str] = Field(default_factory=list)
+    exit_code: int
+    stdout: str = ""
+    duration_s: Optional[float] = None
+
+
 class TurnOutput(BaseModel):
     """Normalized output from a single conversation turn, produced by an agent.
 
@@ -158,6 +174,14 @@ class TurnOutput(BaseModel):
     llm_turn_count: Optional[int] = None
     thinking_text: Optional[str] = None
     tool_sequence: list[str] = Field(default_factory=list)
+
+    # ── Verify results (populated by the runner when a VerifySpec is set) ──
+    # ``verify_result`` is the per-turn ``Turn.verify`` outcome; the per-scenario
+    # ``Scenario.verify`` outcome is recorded on the final turn under
+    # ``scenario_verify_result``. Distinct fields so a scenario using both on
+    # the last turn never collides. See docs/glossary/SECURITY-MODEL.md.
+    verify_result: Optional[VerifyResult] = None
+    scenario_verify_result: Optional[VerifyResult] = None
 
 
 class ScenarioScore(BaseModel):

--- a/src/belt/envvars.py
+++ b/src/belt/envvars.py
@@ -44,6 +44,7 @@ SILENCE_CUSTOM_BASE_URL_WARNING: Final[str] = "BELT_SILENCE_CUSTOM_BASE_URL_WARN
 ALLOW_INSECURE_BASE_URL: Final[str] = "BELT_ALLOW_INSECURE_BASE_URL"
 ALLOW_EXTERNAL_WORKING_DIR: Final[str] = "BELT_ALLOW_EXTERNAL_WORKING_DIR"
 ALLOW_INPLACE: Final[str] = "BELT_ALLOW_INPLACE"
+ALLOW_VERIFY_EXEC: Final[str] = "BELT_ALLOW_VERIFY_EXEC"
 SANDBOX_PROVIDER: Final[str] = "BELT_SANDBOX_PROVIDER"
 NO_DOTENV: Final[str] = "BELT_NO_DOTENV"
 NO_UMASK: Final[str] = "BELT_NO_UMASK"
@@ -123,6 +124,7 @@ PUBLIC_ALLOW: Final[frozenset[str]] = frozenset(
         ALLOW_FULL_ENV,
         ALLOW_INPLACE,
         ALLOW_INSECURE_BASE_URL,
+        ALLOW_VERIFY_EXEC,
         ANTHROPIC_BASE_URL,
         DEBUG,
         LOG_LEVEL,
@@ -151,6 +153,7 @@ ALL_NAMES: Final[frozenset[str]] = frozenset(
         ALLOW_FULL_ENV,
         ALLOW_INPLACE,
         ALLOW_INSECURE_BASE_URL,
+        ALLOW_VERIFY_EXEC,
         ANTHROPIC_API_KEY,
         ANTHROPIC_BASE_URL,
         AZURE_CLIENT_ID,
@@ -228,6 +231,7 @@ _SECURITY_TOGGLE_FLAG_TO_ENV: Final[tuple[tuple[str, str], ...]] = (
     ("allow_arbitrary_exporter", ALLOW_ARBITRARY_EXPORTER),
     ("allow_arbitrary_scorer", ALLOW_ARBITRARY_SCORER),
     ("allow_insecure_base_url", ALLOW_INSECURE_BASE_URL),
+    ("allow_verify_exec", ALLOW_VERIFY_EXEC),
 )
 
 

--- a/src/belt/runner/orchestrator.py
+++ b/src/belt/runner/orchestrator.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
+import time
 import traceback
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any
@@ -25,6 +27,7 @@ from belt import envvars
 from belt._git import run_git
 from belt._io import write_json
 from belt._redact import safe_agent_args
+from belt._sanitize import strip_ansi
 from belt.agent.error_types import UNKNOWN
 from belt.constants import (
     RUNTIME_INFO_FILE,
@@ -35,14 +38,14 @@ from belt.constants import (
     TURN_STATE_TEMPLATE,
     TURN_STREAM_TEMPLATE,
 )
-from belt.entities import TurnOutput
+from belt.entities import TurnOutput, VerifyResult
 from belt.errors import ScenarioError
 from belt.parser.ndjson import bounded_json_loads
 from belt.runner.entities import AgentConfig, ScenarioResult
 from belt.runner.process.spawner import LocalSpawner, SandboxedSpawner, SubprocessRunner
 from belt.runner.sandbox import BaseSandboxProvider, SandboxHandle, get_sandbox_provider
 from belt.runner.sandbox.base import SandboxContext
-from belt.scenario import GroupConfig, SandboxProfile, Scenario, StateExpectation
+from belt.scenario import GroupConfig, SandboxProfile, Scenario, StateExpectation, VerifySpec
 
 if TYPE_CHECKING:
     from belt.agent.base import BaseAgentAdapter
@@ -379,6 +382,15 @@ def run_scenario_turns(
             if isolated_ws is not None and workspace_manager is not None:
                 _capture_git_state(turn_output, workspace_manager, isolated_ws)
 
+            # Per-turn ``verify``: run the author-declared command in the
+            # worktree after capture. Skipped when the agent errored on this
+            # turn (the worktree state is meaningless) -> the scorer emits a
+            # skipped (passed=None) check rather than a false fail. The setup
+            # gate already enforced --allow-verify-exec + worktree presence.
+            if turn.verify is not None and isolated_ws is not None and not turn_output.has_error:
+                logger.info("  turn {}: verify -> {}", i, " ".join(turn.verify.cmd))
+                turn_output.verify_result = _run_verify_command(turn.verify, spawner, ws)
+
             # Record the finalized turn output (post-capture, so any later
             # ``{{prev.git_diff}}`` or ``{{prev.tool_sequence}}`` reference
             # picks up the populated fields).
@@ -398,6 +410,22 @@ def run_scenario_turns(
                 parts.append(f"${turn_output.cost_usd:.4f}")
             logger.info("    captured: {}", ", ".join(parts))
             completed += 1
+
+        # Per-scenario ``verify`` (end-of-conversation): run once after every
+        # turn completed, while the worktree still exists. Recorded on the
+        # final turn's output under ``scenario_verify_result`` (re-written so
+        # the on-disk artifact carries it). Skipped if the conversation did
+        # not run to completion (an early break leaves stale workspace state).
+        if (
+            scenario.verify is not None
+            and isolated_ws is not None
+            and completed == len(scenario.turns)
+            and turn_outputs_so_far
+        ):
+            logger.info("  scenario verify -> {}", " ".join(scenario.verify.cmd))
+            last_output = turn_outputs_so_far[-1]
+            last_output.scenario_verify_result = _run_verify_command(scenario.verify, spawner, ws)
+            _write_turn_artifacts(outcome_dir, completed - 1, last_output)
     finally:
         try:
             meta = agent.metadata()
@@ -456,6 +484,78 @@ def _capture_git_state(
         turn_output.files_modified = files_modified
     except Exception as e:
         logger.warning("Failed to capture git state from worktree: {}", e)
+
+
+# Byte cap on captured ``verify`` stdout. A hostile or runaway test command
+# could otherwise emit unbounded output and OOM the runner; the cap bounds
+# resident memory regardless of how chatty the command is.
+_VERIFY_STDOUT_CAP_BYTES = 1 * 1024 * 1024
+
+
+def _run_verify_command(spec: VerifySpec, spawner: SubprocessRunner, workspace: Path) -> VerifyResult:
+    """Execute a ``VerifySpec`` command in ``workspace`` and capture the result.
+
+    Runs through ``spawner`` so the command lands inside the active sandbox
+    (the docker provider mounts only the worktree; the host provider runs it
+    in ``workspace`` directly). The environment is the minimal base set with
+    NO provider credentials - a verify command is a test runner, not the
+    agent, so it has no business seeing API keys. stdout is captured under a
+    byte cap, the command is bounded by ``spec.timeout``, and a timeout kills
+    the whole process group. Never raises: any failure to spawn collapses to
+    a non-zero ``exit_code`` so scoring always has a deterministic result.
+    """
+    from belt.agent.base import _kill_process_tree, build_subprocess_env
+
+    env = build_subprocess_env()
+    start = time.monotonic()
+    try:
+        proc = spawner.popen(
+            list(spec.cmd),
+            cwd=str(workspace),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+    except Exception as e:  # noqa: BLE001 - report any spawn failure as a non-zero verify result
+        logger.warning("verify command failed to start: {}", e)
+        return VerifyResult(
+            cmd=list(spec.cmd), exit_code=127, stdout=f"verify command failed to start: {e}", duration_s=0.0
+        )
+
+    # ``communicate(timeout=...)`` reads stdout AND enforces the deadline in one
+    # call - reading the pipe to EOF first would block past the timeout. On a
+    # timeout we kill the whole process group and drain what was buffered.
+    # Captured stdout is untrusted command output, so it is ANSI/OSC-stripped at
+    # capture (``strip_ansi``) before storage - a terminal-escape sequence can
+    # never reach a future renderer or split an ``output_contains`` match - then
+    # truncated to the byte cap so the stored / scored output stays bounded.
+    # (Same posture as ``_capture_cli_version``; newlines are preserved so
+    # multi-line test output stays readable.)
+    try:
+        stdout, _ = proc.communicate(timeout=spec.timeout)
+    except subprocess.TimeoutExpired:
+        _kill_process_tree(proc)
+        try:
+            stdout, _ = proc.communicate(timeout=5)
+        except Exception:  # noqa: BLE001 - best-effort drain after kill
+            stdout = ""
+        capped = strip_ansi(stdout or "")[:_VERIFY_STDOUT_CAP_BYTES]
+        return VerifyResult(
+            cmd=list(spec.cmd),
+            exit_code=124,
+            stdout=capped + f"\n...[verify timed out after {spec.timeout}s]",
+            duration_s=time.monotonic() - start,
+        )
+
+    rc = proc.returncode if proc.returncode is not None else 1
+    return VerifyResult(
+        cmd=list(spec.cmd),
+        exit_code=rc,
+        stdout=strip_ansi(stdout or "")[:_VERIFY_STDOUT_CAP_BYTES],
+        duration_s=time.monotonic() - start,
+    )
 
 
 def _safe_resolve(workspace: Path, rel_path: str) -> Path | None:

--- a/src/belt/runner/phases/setup_groups.py
+++ b/src/belt/runner/phases/setup_groups.py
@@ -193,6 +193,52 @@ def _check_inplace_gate(ctx: RunContext) -> None:
         ctx.progress.console.print(f"\n  [red]\u2717[/red] {mg.name}: {cause}")
 
 
+def _check_verify_gate(ctx: RunContext) -> None:
+    """Reject groups whose scenarios declare ``verify`` unless opted in and isolated.
+
+    A ``verify`` block (``Turn.verify`` or ``Scenario.verify``) runs an
+    author-supplied command in the worktree, so it is default-deny - exactly
+    like ``--allow-inplace`` and ``--allow-external-working-dir``. Two
+    conditions are enforced here, before any agent runs:
+
+    1. **Opt-in.** ``--allow-verify-exec`` (or ``BELT_ALLOW_VERIFY_EXEC=1``)
+       must be set; otherwise the group is refused with a remediation line.
+    2. **Isolated worktree.** ``verify`` only runs inside a per-scenario
+       worktree (``working_dir`` or ``fixture_repo`` with
+       ``workspace_isolation: git-worktree``); without one the command would
+       execute in the operator CWD, so the group is refused.
+
+    See ``docs/glossary/SECURITY-MODEL.md`` for the threat model.
+    """
+    allowed = bool(getattr(ctx.args, "allow_verify_exec", False)) or envvars.is_truthy(envvars.ALLOW_VERIFY_EXEC)
+    for mg in ctx.matched_groups:
+        if mg.name in ctx.failed_groups:
+            continue
+        has_verify = any(scn.verify is not None or any(t.verify is not None for t in scn.turns) for scn in mg.scenarios)
+        if not has_verify:
+            continue
+        if not allowed:
+            cause = (
+                "a scenario declares `verify` (deterministic command execution). "
+                f"Re-run with --allow-verify-exec (or set {envvars.ALLOW_VERIFY_EXEC}=1) to opt in."
+            )
+            ctx.failed_groups.add(mg.name)
+            ctx.setup_errors[mg.name] = cause
+            ctx.progress.console.print(f"\n  [red]\u2717[/red] {mg.name}: {cause}")
+            continue
+        gc = mg.config
+        has_worktree = bool(gc.working_dir or gc.fixture_repo) and gc.workspace_isolation == "git-worktree"
+        if not has_worktree:
+            cause = (
+                "`verify` requires an isolated worktree. Set working_dir (or fixture_repo) "
+                "with workspace_isolation: git-worktree so the command runs in a per-scenario "
+                "copy, not the operator's working directory."
+            )
+            ctx.failed_groups.add(mg.name)
+            ctx.setup_errors[mg.name] = cause
+            ctx.progress.console.print(f"\n  [red]\u2717[/red] {mg.name}: {cause}")
+
+
 def _prepare_group_fixtures(ctx: RunContext) -> None:
     """Clone every group's ``fixture_repo`` into a per-run cache directory.
 
@@ -338,6 +384,7 @@ def setup_groups(ctx: RunContext) -> int | None:
     """Set up agent groups in parallel. Returns exit code on fatal failure, None on success."""
     _check_external_working_dir_gate(ctx)
     _check_inplace_gate(ctx)
+    _check_verify_gate(ctx)
     _prepare_group_fixtures(ctx)
     total_groups = len(ctx.matched_groups)
     ctx.progress.console.print(f"\nSetting up [bold]{total_groups}[/bold] group(s)...", end=" ")

--- a/src/belt/scenario.py
+++ b/src/belt/scenario.py
@@ -270,6 +270,49 @@ class TurnJudgeOverride(BaseModel):
     skip: bool = False
 
 
+class VerifySpec(BaseModel):
+    """A deterministic verification command run in the scenario worktree.
+
+    Declared on :attr:`Turn.verify` (runs after that turn) or
+    :attr:`Scenario.verify` (runs once after the final turn). The runner
+    executes ``cmd`` in the per-scenario worktree, through the active sandbox
+    provider, and records the exit code and captured stdout into
+    :class:`belt.entities.TurnOutput` for the rule-based scorer to assert on.
+
+    Security envelope (see ``docs/glossary/SECURITY-MODEL.md``): ``cmd`` is an
+    argv list, never a shell string; the command runs only with an isolated
+    worktree and only when ``--allow-verify-exec`` (or
+    ``BELT_ALLOW_VERIFY_EXEC=1``) is set - the runner refuses the group at
+    setup otherwise (default-deny, because this executes an author-supplied
+    command). ``output_contains`` entries are plain substrings, not regex.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    cmd: list[str] = Field(
+        min_length=1,
+        description="Command argv (no shell). E.g. ['python', '-m', 'pytest', '-q'].",
+    )
+    exit_code: int = Field(default=0, description="Expected process exit code (the check passes when it matches).")
+    output_contains: list[str] = Field(
+        default_factory=list,
+        max_length=50,
+        description="Plain substrings (not regex) that must ALL appear in captured stdout.",
+    )
+    timeout: int = Field(
+        default=300,
+        gt=0,
+        description="Maximum seconds before the command is killed; a timeout fails the check.",
+    )
+
+    @field_validator("cmd")
+    @classmethod
+    def _reject_empty_argv(cls, v: list[str]) -> list[str]:
+        if not v or any((not isinstance(a, str) or a == "") for a in v):
+            raise ValueError("verify.cmd must be a non-empty list of non-empty strings (argv form, no shell).")
+        return v
+
+
 class Turn(BaseModel):
     """A single conversation turn."""
 
@@ -279,6 +322,10 @@ class Turn(BaseModel):
     flags: list[str] = Field(default_factory=list, max_length=50)
     expect: TurnExpectation = Field(default_factory=TurnExpectation)
     state_expect: StateExpectation = Field(default_factory=StateExpectation)
+    verify: Optional[VerifySpec] = Field(
+        default=None,
+        description="Deterministic command run after this turn in the worktree; asserted as the `verify` dimension.",
+    )
     # Per-turn LLM judge overrides. Keyed by judge name (matches the
     # name declared in ``--scorer-config`` YAML, or the implicit
     # ``"llm"`` judge name for single-judge runs). ``max_length=10``
@@ -328,6 +375,13 @@ class Scenario(BaseModel):
         ),
     )
     turns: list[Turn] = Field(max_length=100)
+    verify: Optional[VerifySpec] = Field(
+        default=None,
+        description=(
+            "Deterministic command run once after the final turn (end-of-conversation), "
+            "in the worktree; asserted as the `verify` dimension."
+        ),
+    )
 
     # Set by ``ScenarioLoader.load_scenario`` to the directory containing the
     # scenario JSON. Used by the LLM scorer to resolve

--- a/src/belt/scorer/rules/scorer.py
+++ b/src/belt/scorer/rules/scorer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from loguru import logger
 
 from belt.entities import Scenario, ScorerResult, StateExpectation, TurnExpectation, TurnOutput
+from belt.scenario import VerifySpec
 from belt.scorer.base import BaseScorer
 from belt.scorer.payloads import CheckEntry, RulesPayload
 from belt.scorer.rules.efficiency import check_cost, check_efficiency
@@ -21,6 +22,7 @@ from belt.scorer.rules.performance import check_performance
 from belt.scorer.rules.response import check_response
 from belt.scorer.rules.state import check_state, has_state_checks
 from belt.scorer.rules.trajectory import check_trajectory
+from belt.scorer.rules.verify import check_verify, has_verify
 
 
 class RuleBasedScorer(BaseScorer):
@@ -40,11 +42,18 @@ class RuleBasedScorer(BaseScorer):
         for i, turn in enumerate(scenario.turns):
             to = turn_outputs[i] if i < len(turn_outputs) else TurnOutput(raw_cli="")
             se = turn.state_expect if has_state_checks(turn.state_expect) else None
-            checks = _check_turn(i, to, turn.expect, state_expect=se)
+            checks = _check_turn(i, to, turn.expect, state_expect=se, verify=turn.verify)
             all_checks.extend(checks)
             failed = [c for c in checks if not c.passed]
             if failed:
                 logger.debug("Turn {} rule failures: {}", i, [c.check for c in failed])
+
+        # Per-scenario (end-of-conversation) verify: a turn-less check that
+        # reads the result recorded by the runner on the final turn. Emitted
+        # even when no turns ran (skipped) so the dimension is always present.
+        if scenario.verify is not None:
+            last_result = turn_outputs[-1].scenario_verify_result if turn_outputs else None
+            all_checks.extend(check_verify(scenario.verify, last_result, turn_idx=None))
 
         payload = RulesPayload(checks=all_checks, passed=all(c.passed for c in all_checks))
         return ScorerResult(passed=payload.passed, data=payload)
@@ -55,6 +64,7 @@ def _check_turn(
     output: TurnOutput,
     expect: TurnExpectation,
     state_expect: StateExpectation | None = None,
+    verify: VerifySpec | None = None,
 ) -> list[CheckEntry]:
     results: list[CheckEntry] = []
     results.extend(check_execution(turn_idx, output, expect))
@@ -67,4 +77,6 @@ def _check_turn(
         results.extend(check_file_diff(turn_idx, output, expect))
     if state_expect is not None:
         results.extend(check_state(turn_idx, output, state_expect))
+    if has_verify(verify):
+        results.extend(check_verify(verify, output.verify_result, turn_idx=turn_idx))
     return results

--- a/src/belt/scorer/rules/verify.py
+++ b/src/belt/scorer/rules/verify.py
@@ -1,0 +1,114 @@
+# (c) JFrog Ltd. (2026)
+
+"""Verify checks - assert on a deterministic command's captured result.
+
+The runner executes a ``VerifySpec`` command in the worktree and records a
+:class:`belt.entities.VerifyResult` (per-turn on ``TurnOutput.verify_result``,
+per-scenario on the final turn's ``TurnOutput.scenario_verify_result``). This
+module turns that result into ``CheckEntry`` rows under the ``verify``
+dimension - so ``--threshold rules/verify:0`` gates on it like any other
+dimension. A missing result (command did not run, e.g. the agent errored on
+that turn) is reported as a tri-state skip (``passed=None``), never a false
+failure.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from belt._sanitize import sanitize
+from belt.entities import VerifyResult
+from belt.scenario import VerifySpec
+from belt.scorer.payloads import CheckEntry
+
+# Length of the stdout excerpt surfaced in a failure ``details`` so a user can
+# see WHY the command failed (e.g. the pytest error) without opening
+# ``turn_N_output.json``. Kept short so it fits a one-line table cell.
+_DETAILS_STDOUT_TAIL_CHARS = 240
+
+
+def _stdout_tail(stdout: str) -> str:
+    """Return a single-line, sanitized tail of ``stdout`` for a failure message.
+
+    The runner already ANSI-strips captured stdout; this additionally strips
+    residual control bytes and collapses whitespace via
+    :func:`belt._sanitize.sanitize` so the excerpt is safe to drop into a
+    one-line ``details`` cell (the per-sink exporters still escape ``details``
+    on top of this). Returns ``""`` when there is nothing useful to show.
+    """
+    cleaned = " ".join(sanitize(stdout or "").split())
+    if not cleaned:
+        return ""
+    if len(cleaned) > _DETAILS_STDOUT_TAIL_CHARS:
+        cleaned = "..." + cleaned[-_DETAILS_STDOUT_TAIL_CHARS:]
+    return cleaned
+
+
+def has_verify(spec: Optional[VerifySpec]) -> bool:
+    """True when a ``verify`` block is declared for this turn / scenario."""
+    return spec is not None
+
+
+def check_verify(
+    spec: VerifySpec,
+    result: Optional[VerifyResult],
+    *,
+    turn_idx: Optional[int],
+) -> list[CheckEntry]:
+    """Assert a captured verify ``result`` against its ``spec``.
+
+    ``turn_idx`` is the turn index for a per-turn verify, or ``None`` for a
+    per-scenario (end-of-conversation) verify - a turn-less ``CheckEntry``
+    that the renderers already handle. A ``None`` ``result`` means the command
+    never ran; emit a single skipped check.
+    """
+    # Short command label so each check self-describes WHAT ran (parallels
+    # ``[state] file_exists(path)``); the dimension tag is already ``verify``,
+    # so the check text never repeats the word.
+    cmd_label = " ".join(spec.cmd)
+    if len(cmd_label) > 60:
+        cmd_label = cmd_label[:57] + "..."
+
+    if result is None:
+        return [
+            CheckEntry(
+                dimension="verify",
+                check=f"exit_code=={spec.exit_code} ({cmd_label})",
+                passed=None,
+                details="skipped (command did not run)",
+                turn_idx=turn_idx,
+            )
+        ]
+
+    results: list[CheckEntry] = []
+    exit_ok = result.exit_code == spec.exit_code
+    if exit_ok:
+        exit_details = ""
+    else:
+        # Surface a short, sanitized tail of the command's output so a failed
+        # run shows *why* (e.g. the pytest error) right in the report.
+        exit_details = f"got exit_code {result.exit_code}"
+        tail = _stdout_tail(result.stdout)
+        if tail:
+            exit_details += f"; stdout: {tail}"
+    results.append(
+        CheckEntry(
+            dimension="verify",
+            check=f"exit_code=={spec.exit_code} ({cmd_label})",
+            passed=exit_ok,
+            details=exit_details,
+            turn_idx=turn_idx,
+        )
+    )
+    for substring in spec.output_contains:
+        found = substring in (result.stdout or "")
+        results.append(
+            CheckEntry(
+                dimension="verify",
+                check=f"stdout contains {substring!r}",
+                passed=found,
+                details="" if found else "substring not found in stdout",
+                turn_idx=turn_idx,
+            )
+        )
+    return results

--- a/tests/scorer/rules/test_verify.py
+++ b/tests/scorer/rules/test_verify.py
@@ -1,0 +1,241 @@
+# (c) JFrog Ltd. (2026)
+
+"""Tests for the deterministic ``verify`` exec-test grader.
+
+Covers the schema (``VerifySpec``), the scorer (``check_verify`` + rules
+integration), the runner helper (``_run_verify_command``), and the setup
+gate (``_check_verify_gate``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from belt.entities import TurnOutput, VerifyResult
+from belt.scenario import GroupConfig, Scenario, Turn, VerifySpec
+from belt.scorer.rules.scorer import RuleBasedScorer
+from belt.scorer.rules.verify import check_verify, has_verify
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+
+class TestVerifySpecSchema:
+    def test_minimal_valid(self):
+        spec = VerifySpec(cmd=["python", "-m", "pytest"])
+        assert spec.exit_code == 0
+        assert spec.output_contains == []
+        assert spec.timeout > 0
+
+    def test_rejects_empty_cmd(self):
+        with pytest.raises(ValueError):
+            VerifySpec(cmd=[])
+
+    def test_rejects_empty_string_argv(self):
+        with pytest.raises(ValueError):
+            VerifySpec(cmd=["python", ""])
+
+    def test_rejects_unknown_field(self):
+        with pytest.raises(ValueError):
+            VerifySpec(cmd=["x"], shell=True)  # type: ignore[call-arg]
+
+
+# ── check_verify ────────────────────────────────────────────────────────────
+
+
+class TestCheckVerify:
+    def test_has_verify(self):
+        assert has_verify(VerifySpec(cmd=["x"])) is True
+        assert has_verify(None) is False
+
+    def test_pass_exit_and_substring(self):
+        spec = VerifySpec(cmd=["mytool", "--run"], exit_code=0, output_contains=["passed"])
+        result = VerifyResult(exit_code=0, stdout="3 passed in 0.1s")
+        checks = check_verify(spec, result, turn_idx=0)
+        assert all(c.passed for c in checks)
+        assert all(c.dimension == "verify" for c in checks)
+        # Check names self-describe (no stutter) and carry the command.
+        assert any(c.check == "exit_code==0 (mytool --run)" for c in checks)
+        assert any(c.check == "stdout contains 'passed'" for c in checks)
+        assert not any(c.check.startswith("verify ") for c in checks)
+
+    def test_fail_on_exit_mismatch(self):
+        spec = VerifySpec(cmd=["x"], exit_code=0)
+        result = VerifyResult(exit_code=1, stdout="boom")
+        checks = check_verify(spec, result, turn_idx=0)
+        assert checks[0].passed is False
+        assert "got exit_code 1" in checks[0].details
+
+    def test_failure_details_include_sanitized_stdout_tail(self):
+        spec = VerifySpec(cmd=["x"], exit_code=0)
+        # Multi-line output with an embedded ANSI escape; the failure details
+        # must surface the error tail as a single sanitized line (no ESC, no
+        # newlines) so it is safe in a one-line table cell.
+        result = VerifyResult(exit_code=1, stdout="setup\nFAILED tests/test_x.py::test_y\n\x1b[31mboom\x1b[0m")
+        details = check_verify(spec, result, turn_idx=0)[0].details
+        assert "got exit_code 1" in details
+        assert "FAILED tests/test_x.py::test_y" in details
+        assert "\x1b" not in details
+        assert "\n" not in details
+
+    def test_fail_on_missing_substring(self):
+        spec = VerifySpec(cmd=["x"], output_contains=["passed"])
+        result = VerifyResult(exit_code=0, stdout="0 selected")
+        checks = check_verify(spec, result, turn_idx=0)
+        substr_check = [c for c in checks if "contains" in c.check][0]
+        assert substr_check.passed is False
+
+    def test_skip_when_result_missing(self):
+        spec = VerifySpec(cmd=["x"])
+        checks = check_verify(spec, None, turn_idx=2)
+        assert len(checks) == 1
+        assert checks[0].passed is None  # tri-state skip, not a failure
+        assert checks[0].turn_idx == 2
+
+    def test_scenario_level_is_turn_less(self):
+        spec = VerifySpec(cmd=["x"])
+        checks = check_verify(spec, VerifyResult(exit_code=0), turn_idx=None)
+        assert all(c.turn_idx is None for c in checks)
+
+
+# ── Rules scorer integration ────────────────────────────────────────────────
+
+
+class TestRulesScorerVerify:
+    def test_per_turn_verify_emits_check(self):
+        scenario = Scenario(
+            name="s",
+            description="d",
+            turns=[Turn(message="m", verify=VerifySpec(cmd=["true"], output_contains=["ok"]))],
+        )
+        output = TurnOutput(raw_cli="", verify_result=VerifyResult(exit_code=0, stdout="ok"))
+        result = RuleBasedScorer().score(scenario, [output])
+        verify_checks = [c for c in result.data.checks if c.dimension == "verify"]
+        assert verify_checks and all(c.passed for c in verify_checks)
+
+    def test_per_scenario_verify_reads_final_turn(self):
+        scenario = Scenario(
+            name="s",
+            description="d",
+            turns=[Turn(message="a"), Turn(message="b")],
+            verify=VerifySpec(cmd=["true"]),
+        )
+        outputs = [
+            TurnOutput(raw_cli=""),
+            TurnOutput(raw_cli="", scenario_verify_result=VerifyResult(exit_code=0)),
+        ]
+        result = RuleBasedScorer().score(scenario, outputs)
+        verify_checks = [c for c in result.data.checks if c.dimension == "verify"]
+        assert len(verify_checks) == 1
+        assert verify_checks[0].turn_idx is None
+        assert verify_checks[0].passed is True
+
+    def test_per_scenario_verify_skipped_when_no_turns(self):
+        scenario = Scenario(name="s", description="d", turns=[Turn(message="a")], verify=VerifySpec(cmd=["true"]))
+        # No turn output captured a scenario_verify_result -> skipped, not failed.
+        result = RuleBasedScorer().score(scenario, [TurnOutput(raw_cli="")])
+        verify_checks = [c for c in result.data.checks if c.dimension == "verify"]
+        assert verify_checks[0].passed is None
+
+
+# ── Runner helper ───────────────────────────────────────────────────────────
+
+
+class TestRunVerifyCommand:
+    def test_success(self, tmp_path):
+        from belt.runner.orchestrator import _run_verify_command
+        from belt.runner.process.spawner import LocalSpawner
+
+        spec = VerifySpec(cmd=["python", "-c", "print('hello-verify')"])
+        result = _run_verify_command(spec, LocalSpawner(), tmp_path)
+        assert result.exit_code == 0
+        assert "hello-verify" in result.stdout
+        assert result.cmd == spec.cmd  # self-describing artifact
+
+    def test_nonzero_exit(self, tmp_path):
+        from belt.runner.orchestrator import _run_verify_command
+        from belt.runner.process.spawner import LocalSpawner
+
+        spec = VerifySpec(cmd=["python", "-c", "import sys; sys.exit(3)"])
+        result = _run_verify_command(spec, LocalSpawner(), tmp_path)
+        assert result.exit_code == 3
+
+    def test_timeout_is_killed(self, tmp_path):
+        from belt.runner.orchestrator import _run_verify_command
+        from belt.runner.process.spawner import LocalSpawner
+
+        spec = VerifySpec(cmd=["python", "-c", "import time; time.sleep(30)"], timeout=1)
+        result = _run_verify_command(spec, LocalSpawner(), tmp_path)
+        assert result.exit_code == 124
+        assert "timed out" in result.stdout
+
+    def test_ansi_stripped_at_capture(self, tmp_path):
+        from belt.runner.orchestrator import _run_verify_command
+        from belt.runner.process.spawner import LocalSpawner
+
+        # Command emits an ANSI colour sequence; it must be stripped before the
+        # captured stdout is stored, so no escape can reach a future renderer.
+        spec = VerifySpec(cmd=["python", "-c", r"print('\x1b[31mRED\x1b[0m done')"])
+        result = _run_verify_command(spec, LocalSpawner(), tmp_path)
+        assert result.exit_code == 0
+        assert "\x1b" not in result.stdout
+        assert "RED done" in result.stdout
+
+
+# ── Setup gate ──────────────────────────────────────────────────────────────
+
+
+def _fake_ctx(*, allow: bool, group_config: GroupConfig, scenario: Scenario):
+    mg = SimpleNamespace(name="g", scenarios=[scenario], config=group_config)
+    return SimpleNamespace(
+        args=SimpleNamespace(allow_verify_exec=allow),
+        matched_groups=[mg],
+        failed_groups=set(),
+        setup_errors={},
+        progress=SimpleNamespace(console=SimpleNamespace(print=lambda *a, **k: None)),
+    )
+
+
+class TestVerifyGate:
+    def _scn_with_verify(self) -> Scenario:
+        return Scenario(name="s", description="d", turns=[Turn(message="m", verify=VerifySpec(cmd=["true"]))])
+
+    def test_refused_when_gate_off(self, monkeypatch):
+        from belt.runner.phases.setup_groups import _check_verify_gate
+
+        monkeypatch.delenv("BELT_ALLOW_VERIFY_EXEC", raising=False)
+        gc = GroupConfig(agent="cursor", working_dir="../x", workspace_isolation="git-worktree")
+        ctx = _fake_ctx(allow=False, group_config=gc, scenario=self._scn_with_verify())
+        _check_verify_gate(ctx)
+        assert "g" in ctx.failed_groups
+        assert "allow-verify-exec" in ctx.setup_errors["g"]
+
+    def test_allowed_with_worktree(self, monkeypatch):
+        from belt.runner.phases.setup_groups import _check_verify_gate
+
+        monkeypatch.delenv("BELT_ALLOW_VERIFY_EXEC", raising=False)
+        gc = GroupConfig(agent="cursor", working_dir="../x", workspace_isolation="git-worktree")
+        ctx = _fake_ctx(allow=True, group_config=gc, scenario=self._scn_with_verify())
+        _check_verify_gate(ctx)
+        assert ctx.failed_groups == set()
+
+    def test_refused_without_worktree(self, monkeypatch):
+        from belt.runner.phases.setup_groups import _check_verify_gate
+
+        monkeypatch.delenv("BELT_ALLOW_VERIFY_EXEC", raising=False)
+        gc = GroupConfig(agent="cursor")  # no working_dir / fixture_repo
+        ctx = _fake_ctx(allow=True, group_config=gc, scenario=self._scn_with_verify())
+        _check_verify_gate(ctx)
+        assert "g" in ctx.failed_groups
+        assert "isolated worktree" in ctx.setup_errors["g"]
+
+    def test_no_verify_is_untouched(self, monkeypatch):
+        from belt.runner.phases.setup_groups import _check_verify_gate
+
+        monkeypatch.delenv("BELT_ALLOW_VERIFY_EXEC", raising=False)
+        gc = GroupConfig(agent="cursor", working_dir="../x", workspace_isolation="git-worktree")
+        plain = Scenario(name="s", description="d", turns=[Turn(message="m")])
+        ctx = _fake_ctx(allow=False, group_config=gc, scenario=plain)
+        _check_verify_gate(ctx)
+        assert ctx.failed_groups == set()

--- a/tests/test_scenarios_layout.py
+++ b/tests/test_scenarios_layout.py
@@ -185,3 +185,35 @@ def test_showcase_demonstrates_every_group_config_field() -> None:
         "Add the field to examples/scenarios/showcase/group-config-fields/_config.json "
         "or another existing showcase _config.json that demonstrates it."
     )
+
+
+def test_showcase_demonstrates_verify_field() -> None:
+    """`Turn.verify` and `Scenario.verify` must each be exercised by a showcase scenario.
+
+    The crawls above only cover ``expect`` / ``state_expect`` / ``_config.json``
+    keys, so the `Turn`/`Scenario`-level ``verify`` field needs its own guard -
+    otherwise the deterministic exec-test grader could ship with no worked
+    example. Mirrors the per-field coverage the other guards enforce.
+    """
+    import json
+
+    turn_verify = False
+    scenario_verify = False
+    for jf in SHOWCASE_ROOT.rglob("*.json"):
+        if jf.name == "_config.json" or jf.name.startswith("_"):
+            continue
+        data = json.loads(jf.read_text())
+        if "verify" in data:
+            scenario_verify = True
+        for turn in data.get("turns", []):
+            if "verify" in turn:
+                turn_verify = True
+
+    assert turn_verify, (
+        "No showcase scenario exercises `Turn.verify`. Add one under "
+        "examples/scenarios/showcase/verify/ that sets `verify` on a turn."
+    )
+    assert scenario_verify, (
+        "No showcase scenario exercises `Scenario.verify`. Add one under "
+        "examples/scenarios/showcase/verify/ that sets a top-level `verify`."
+    )


### PR DESCRIPTION
Closes #9.

## Summary

Adds a deterministic `verify` step - the exec-test grader. A scenario declares
`verify` either on a turn (`Turn.verify`) or on the scenario
(`Scenario.verify`, end-of-conversation). The runner executes the
author-declared command in the per-scenario worktree and records the exit code
+ captured stdout into `TurnOutput`; the rule-based scorer asserts it as the
`verify` dimension (gate with `--threshold rules/verify:0`). This is the
strongest, cheapest grader for code-editing scenarios - "did the agent's change
make the project's own test suite pass?" - the deterministic half an LLM judge
can't match.

## Design (no new payload, no signature change)

- **Schema** (`scenario.py`): one `VerifySpec` (`cmd` argv, `exit_code`,
  `output_contains` plain substrings, `timeout`) on `Turn.verify` /
  `Scenario.verify` (parallel to `state_expect`).
- **Artifact** (`entities.py`): `TurnOutput.verify_result` (per-turn) and
  `scenario_verify_result` on the final turn (per-scenario) - additive.
- **Runner** (`orchestrator.py`): execute + capture via the orchestrator's own
  sandbox `spawner`; per-turn after git-state capture, per-scenario after the
  loop while the worktree still exists. Skip-on-agent-error -> tri-state
  `passed=None` (not a false fail).
- **Scorer** (`scorer/rules/verify.py`): `check_verify` / `has_verify` wired
  alongside `check_state`; per-scenario emits a turn-less `CheckEntry`. Stays a
  `CheckEntry` in `RulesPayload`.

## Security (default-deny)

`verify` runs an author-supplied command, so it is gated behind
`--allow-verify-exec` / `BELT_ALLOW_VERIFY_EXEC`, refused at setup without an
isolated worktree, routed through the active sandbox provider (in-container
under `--sandbox docker`), given a minimal credential-free env, output-capped,
and killed on timeout. Documented in `SECURITY-MODEL.md` (threat T15, control
S5.11, gate table) plus `SCENARIOS.md` / `SCORING.md` / `CONFIGURATION.md` /
`OUTCOMES.md`.

## Example

`examples/scenarios/showcase/verify/` on the `tasktracker` fixture: a per-turn
scenario and a multi-turn per-scenario scenario. (Fixed `tasktracker`'s pytest
`pythonpath` so the src-layout package imports in a bare worktree.)

## Test plan

- [x] New `tests/scorer/rules/test_verify.py`: schema, `check_verify`
      (pass/fail/skip), rules integration (per-turn + per-scenario), runner exec
      incl. timeout, and the setup gate (off / allowed / no-worktree).
- [x] `tests/test_scenarios_layout.py` extended to require `Turn.verify` and
      `Scenario.verify` showcase coverage.
- [x] Full suite: 3243 passed, 23 skipped; lint (black/isort/ruff/markdownlint/
      bandit/gitleaks/design) clean.
- [x] Default-deny verified via CLI (group refused without the flag, exit 1).
- [x] **Real end-to-end run**: agent edits the fixture, `verify` runs pytest in
      the worktree -> `verify_result {exit_code: 0, "10 passed"}`, 5/5 checks.

### Out of scope
- `pre_run` background daemons (separate seam/lifecycle).
- Feeding verify stdout to the LLM judge (follow-up).